### PR TITLE
fix: Validate project-create package name

### DIFF
--- a/.changeset/rare-dogs-provide.md
+++ b/.changeset/rare-dogs-provide.md
@@ -1,0 +1,5 @@
+---
+'@halfdomelabs/create-project': patch
+---
+
+Add naming constraints to created project and lowercase package name

--- a/packages/create-project/src/create-baseplate-project.ts
+++ b/packages/create-project/src/create-baseplate-project.ts
@@ -36,13 +36,24 @@ async function runMain(): Promise<void> {
 
   const directory = program.processedArgs[0] as string;
 
-  console.log(
-    `Creating a new Baseplate project in ${
-      directory === '.' ? 'the current directory' : directory
-    }...\n`,
-  );
-
   const resolvedDirectory = path.resolve(directory);
+
+  const packageName = path
+    .basename(resolvedDirectory)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-');
+
+  if (packageName === '-' || !packageName) {
+    throw new Error(
+      'Directory must have at least one Latin alphanumeric character.',
+    );
+  }
+
+  const relativeDirectory = path.relative(process.cwd(), resolvedDirectory);
+
+  console.log(`Creating a new Baseplate project (${packageName})...`);
+  console.log(`Directory: ${relativeDirectory || '.'}`);
+  console.log();
 
   const hasPackageJson = await checkForPackageJson(resolvedDirectory);
 
@@ -61,6 +72,7 @@ async function runMain(): Promise<void> {
   const { npmToken, cliVersion } = await getNpmTokenAndVersion();
 
   await generateBaseplateProject({
+    packageName,
     directory: resolvedDirectory,
     npmToken,
     cliVersion,

--- a/packages/create-project/src/project-creator.ts
+++ b/packages/create-project/src/project-creator.ts
@@ -7,10 +7,12 @@ import path from 'node:path';
 import ora from 'ora';
 
 export async function generateBaseplateProject({
+  packageName,
   directory,
   npmToken,
   cliVersion,
 }: {
+  packageName: string;
   directory: string;
   npmToken: string;
   cliVersion: string;
@@ -44,14 +46,12 @@ export async function generateBaseplateProject({
       await writeFile(destination, sourceFile);
     };
 
-    const directoryName = path.basename(directory);
-
     // write package.json
     await writeFile(
       'package.json',
       JSON.stringify(
         {
-          name: directoryName,
+          name: packageName,
           version: '0.1.0',
           private: true,
           description: 'A Baseplate project',
@@ -83,7 +83,7 @@ export async function generateBaseplateProject({
       'baseplate/project.json',
       JSON.stringify(
         {
-          name: directoryName,
+          name: packageName,
           features: [],
           models: [],
           portOffset: 3000,


### PR DESCRIPTION
This commit modifies the code to include the ability to create a new Baseplate project with a specified package name. The package name is derived from the directory name and is converted to lowercase with hyphens replacing non-alphanumeric characters. If the package name is empty or contains only hyphens, an error is thrown.