### PR TITLE
fix: Dismiss blocker dialog if no active blocker dialog present

### DIFF
--- a/.changeset/ten-bulldogs-matter.md
+++ b/.changeset/ten-bulldogs-matter.md
@@ -1,0 +1,5 @@
+---
+'@halfdomelabs/project-builder-web': patch
+---
+
+Dismiss blocker dialog if no active blocker dialog present

--- a/packages/project-builder-web/src/components/BlockerDialog/BlockerDialog.tsx
+++ b/packages/project-builder-web/src/components/BlockerDialog/BlockerDialog.tsx
@@ -1,4 +1,5 @@
 import { Button, Dialog } from '@halfdomelabs/ui-components';
+import { useEffect } from 'react';
 import { useBlocker } from 'react-router-dom';
 
 import { useBlockerDialogState } from '@src/hooks/useBlockerDialog';
@@ -16,6 +17,12 @@ export function BlockerDialog(): JSX.Element {
     ({ currentLocation, nextLocation }) =>
       !!activeBlocker && currentLocation.pathname !== nextLocation.pathname,
   );
+
+  useEffect(() => {
+    if (blocker.state === 'blocked' && !activeBlocker) {
+      blocker.proceed();
+    }
+  }, [blocker, activeBlocker]);
 
   return (
     <Dialog


### PR DESCRIPTION
Still shows a flash of blocker dialog so this is more a mitigation than proper fix.