### PR TITLE
fix: Fix Sentry ignored transaction paths logic

### DIFF
--- a/.changeset/large-wasps-rhyme.md
+++ b/.changeset/large-wasps-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@halfdomelabs/fastify-generators": patch
+---
+
+Fix Sentry ignored transaction paths logic

--- a/packages/fastify-generators/src/generators/core/fastify-sentry/templates/instrument.ts
+++ b/packages/fastify-generators/src/generators/core/fastify-sentry/templates/instrument.ts
@@ -20,13 +20,19 @@ if (SENTRY_ENABLED) {
     environment: config.APP_ENVIRONMENT,
     serverName: os.hostname(),
     integrations: SENTRY_INTEGRATIONS,
-    tracesSampler: (samplingContext) => {
+    tracesSampler: ({ parentSampled, attributes }) => {
+      const httpTarget = attributes?.['http.target'];
       if (
-        samplingContext?.request?.url &&
-        IGNORED_TRANSACTION_PATHS.includes(samplingContext?.request?.url)
+        typeof httpTarget === 'string' &&
+        IGNORED_TRANSACTION_PATHS.includes(httpTarget)
       ) {
         return false;
       }
+
+      if (typeof parentSampled === 'boolean') {
+        return parentSampled;
+      }
+
       return SENTRY_TRACES_SAMPLE_RATE;
     },
 

--- a/tests/simple/packages/backend/baseplate/.clean/src/instrument.ts
+++ b/tests/simple/packages/backend/baseplate/.clean/src/instrument.ts
@@ -22,13 +22,19 @@ if (SENTRY_ENABLED) {
       Sentry.requestDataIntegration({ include: { ip: true } }),
       Sentry.prismaIntegration(),
     ],
-    tracesSampler: (samplingContext) => {
+    tracesSampler: ({ parentSampled, attributes }) => {
+      const httpTarget = attributes?.['http.target'];
       if (
-        samplingContext?.request?.url &&
-        IGNORED_TRANSACTION_PATHS.includes(samplingContext?.request?.url)
+        typeof httpTarget === 'string' &&
+        IGNORED_TRANSACTION_PATHS.includes(httpTarget)
       ) {
         return false;
       }
+
+      if (typeof parentSampled === 'boolean') {
+        return parentSampled;
+      }
+
       return SENTRY_TRACES_SAMPLE_RATE;
     },
 

--- a/tests/simple/packages/backend/src/instrument.ts
+++ b/tests/simple/packages/backend/src/instrument.ts
@@ -22,13 +22,19 @@ if (SENTRY_ENABLED) {
       Sentry.requestDataIntegration({ include: { ip: true } }),
       Sentry.prismaIntegration(),
     ],
-    tracesSampler: (samplingContext) => {
+    tracesSampler: ({ parentSampled, attributes }) => {
+      const httpTarget = attributes?.['http.target'];
       if (
-        samplingContext?.request?.url &&
-        IGNORED_TRANSACTION_PATHS.includes(samplingContext?.request?.url)
+        typeof httpTarget === 'string' &&
+        IGNORED_TRANSACTION_PATHS.includes(httpTarget)
       ) {
         return false;
       }
+
+      if (typeof parentSampled === 'boolean') {
+        return parentSampled;
+      }
+
       return SENTRY_TRACES_SAMPLE_RATE;
     },
 


### PR DESCRIPTION
- Use http.target instead of request URL
- Use parentSampled to guide logic of whether to sample trace