### PR TITLE
fix: Fix mock-redis typings for Node16 module resolution

### DIFF
--- a/.changeset/large-baboons-doubt.md
+++ b/.changeset/large-baboons-doubt.md
@@ -1,0 +1,5 @@
+---
+'@halfdomelabs/fastify-generators': patch
+---
+
+Fix mock-redis typings for Node16 module resolution

--- a/packages/fastify-generators/src/generators/core/fastify-redis/templates/mock-redis.ts
+++ b/packages/fastify-generators/src/generators/core/fastify-redis/templates/mock-redis.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { Redis } from 'ioredis';
+import type { Redis } from 'ioredis';
 import { vi } from 'vitest';
 
 // We need to mock Redis otherwise open connections may prevent Vitest from exiting
@@ -33,4 +33,7 @@ Object.keys(IoRedisMock).forEach((key) => {
   )[key];
 });
 
-vi.mock('ioredis', () => ({ default: IoRedisMockAugmented }));
+vi.mock('ioredis', () => ({
+  default: IoRedisMockAugmented,
+  Redis: IoRedisMockAugmented,
+}));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type definitions for mock-redis to improve compatibility with Node.js 16.
	- Updated mock setup for ioredis to include the Redis type in exports.

- **Bug Fixes**
	- Addressed type-related issues for developers using TypeScript with mock-redis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->