### PR TITLE
fix: Pin PNPM to 9.15.0 instead of 9.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "packageManager": "pnpm@9.15.1",
   "engines": {
     "node": "^20.0.0",
-    "pnpm": "^9.15.1"
+    "pnpm": "^9.15.0"
   },
   "volta": {
     "node": "20.18.1"

--- a/packages/create-project/src/project-creator.ts
+++ b/packages/create-project/src/project-creator.ts
@@ -69,7 +69,7 @@ export async function generateBaseplateProject({
           packageManager: 'pnpm@9.15.1',
           engines: {
             node: '^20.18.1',
-            pnpm: '^9.15.1',
+            pnpm: '^9.15.0',
           },
           volta: {
             node: '20.18.1',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated minimum required `pnpm` version from `^9.15.1` to `^9.15.0` in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->