### PR TITLE
refactor: Remove usage of setBaseDirectory

### DIFF
--- a/packages/fastify-generators/src/generators/auth/password-hasher-service/index.ts
+++ b/packages/fastify-generators/src/generators/auth/password-hasher-service/index.ts
@@ -40,7 +40,7 @@ export const passwordHasherServiceGenerator = createGenerator({
       run({ node, appModule, typescript }) {
         const moduleFolder = appModule.getModuleFolder();
 
-        const [fileImport] = makeImportAndFilePath(
+        const [fileImport, filePath] = makeImportAndFilePath(
           path.join(moduleFolder, 'services/password-hasher.service.ts'),
         );
 
@@ -60,10 +60,10 @@ export const passwordHasherServiceGenerator = createGenerator({
             },
           },
           build: async (builder) => {
-            builder.setBaseDirectory(moduleFolder);
             await builder.apply(
               typescript.createCopyAction({
                 source: 'services/password-hasher.service.ts',
+                destination: filePath,
               }),
             );
           },

--- a/packages/react-generators/src/generators/core/react-logger/index.ts
+++ b/packages/react-generators/src/generators/core/react-logger/index.ts
@@ -4,12 +4,14 @@ import type {
 } from '@halfdomelabs/core-generators';
 
 import {
+  makeImportAndFilePath,
   nodeProvider,
   projectScope,
   TypescriptCodeUtils,
   typescriptProvider,
 } from '@halfdomelabs/core-generators';
 import { createGenerator, createProviderType } from '@halfdomelabs/sync';
+import path from 'node:path';
 import { z } from 'zod';
 
 import { reactProvider } from '../react/index.js';
@@ -45,6 +47,10 @@ export const reactLoggerGenerator = createGenerator({
           loglevel: '1.9.1',
         });
 
+        const [fileImport, filePath] = makeImportAndFilePath(
+          path.join(react.getSrcFolder(), 'services/logger.ts'),
+        );
+
         return {
           providers: {
             reactLogger: {
@@ -55,18 +61,17 @@ export const reactLoggerGenerator = createGenerator({
                 ),
               getImportMap: () => ({
                 '%react-logger': {
-                  path: `@/${react.getSrcFolder()}/services/logger`,
+                  path: fileImport,
                   allowedImports: ['logger'],
                 },
               }),
             },
           },
           build: async (builder) => {
-            builder.setBaseDirectory(react.getSrcFolder());
             await builder.apply(
               typescript.createCopyAction({
                 source: 'logger.ts',
-                destination: 'services/logger.ts',
+                destination: filePath,
               }),
             );
           },

--- a/packages/react-generators/src/generators/core/react-router/index.ts
+++ b/packages/react-generators/src/generators/core/react-router/index.ts
@@ -4,6 +4,7 @@ import type {
 } from '@halfdomelabs/core-generators';
 
 import {
+  makeImportAndFilePath,
   nodeProvider,
   projectScope,
   TypescriptCodeUtils,
@@ -11,6 +12,7 @@ import {
   typescriptProvider,
 } from '@halfdomelabs/core-generators';
 import { createGenerator, createProviderType } from '@halfdomelabs/sync';
+import path from 'node:path';
 import { z } from 'zod';
 
 import type { ReactRoute, ReactRouteLayout } from '@src/providers/routes.js';
@@ -100,7 +102,9 @@ export const reactRouterGenerator = createGenerator({
                 `import { Routes } from 'react-router-dom'`,
               );
 
-            builder.setBaseDirectory(react.getSrcFolder());
+            const [pagesImport, pagesPath] = makeImportAndFilePath(
+              path.join(react.getSrcFolder(), 'pages/index.tsx'),
+            );
 
             reactApp
               .getRenderWrappers()
@@ -115,7 +119,7 @@ export const reactRouterGenerator = createGenerator({
             reactApp.setRenderRoot(
               TypescriptCodeUtils.createExpression(
                 '<PagesRoot />',
-                `import PagesRoot from "@/${react.getSrcFolder()}/pages"`,
+                `import PagesRoot from "${pagesImport}"`,
               ),
             );
 
@@ -140,7 +144,7 @@ export const reactRouterGenerator = createGenerator({
             });
 
             await builder.apply(
-              pagesRootFile.renderToAction('pages/index.tsx'),
+              pagesRootFile.renderToAction('pages/index.tsx', pagesPath),
             );
           },
         };

--- a/packages/sync/src/output/generator-task-output.ts
+++ b/packages/sync/src/output/generator-task-output.ts
@@ -146,11 +146,6 @@ export class GeneratorTaskOutputBuilder {
    */
   generatorBaseDirectory: string;
 
-  /**
-   * The base directory to prefix all file paths with
-   */
-  baseDirectory: string | undefined;
-
   constructor(generatorBaseDirectory: string) {
     this.output = {
       files: new Map(),
@@ -201,31 +196,14 @@ export class GeneratorTaskOutputBuilder {
   }
 
   /**
-   * Resolves a path with the given base directory
+   * Resolves a path
    *
    * @param relativePath The path to resolve relative to the base directory
    * @returns The resolved path
    */
   resolvePath(relativePath: string): string {
-    return (
-      (
-        this.baseDirectory
-          ? path.join(this.baseDirectory, relativePath)
-          : relativePath
-      )
-        // normalize all paths to POSIX style / paths
-        .replaceAll(path.sep, path.posix.sep)
-    );
-  }
-
-  /**
-   * Sets the base directory for the generator output
-   * (all files written will be written relative to the base directory)
-   *
-   * @param baseDirectory The base directory to set
-   */
-  setBaseDirectory(baseDirectory: string): void {
-    this.baseDirectory = baseDirectory;
+    // normalize all paths to POSIX style / paths
+    return relativePath.replaceAll(path.sep, path.posix.sep);
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated file path handling in multiple generator services
	- Simplified generator task output builder by removing base directory functionality
	- Enhanced import and file path management across different generator modules

- **Chores**
	- Removed unnecessary base directory configurations
	- Streamlined code for more consistent path resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->