### PR TITLE
fix: Ensure files do not get regenerated when deleted and unmodified

### DIFF
--- a/.changeset/two-garlics-try.md
+++ b/.changeset/two-garlics-try.md
@@ -1,0 +1,5 @@
+---
+'@halfdomelabs/sync': patch
+---
+
+Ensure files are not regenerated if they have been deleted and are unmodified

--- a/packages/sync/src/output/prepare-generator-files/prepare-generator-file.ts
+++ b/packages/sync/src/output/prepare-generator-files/prepare-generator-file.ts
@@ -210,12 +210,12 @@ async function mergeStringContents({
 }
 
 /**
- * Find the relative path of the file in the previous working codebase
+ * Find the relative path of the file in the previous generated codebase
  *
  * @param data - File data
  * @param relativePath - Relative path of the file
  * @param context - Generator output file writer context
- * @returns The relative path of the file in the previous working codebase or undefined if it does not exist
+ * @returns The relative path of the file in the previous generated codebase or undefined if it does not exist
  */
 async function findPreviousRelativePath(
   data: FileData,
@@ -316,9 +316,10 @@ export async function prepareGeneratorFile({
 
   // If we haven't modified the generated version of the file,
   // we use the previous working file version
-  const previousGeneratedBuffer = previousRelativePath
-    ? await previousGeneratedPayload?.fileReader.readFile(previousRelativePath)
-    : undefined;
+  const previousGeneratedBuffer =
+    await previousGeneratedPayload?.fileReader.readFile(
+      previousRelativePath ?? relativePath,
+    );
 
   if (
     previousGeneratedBuffer &&

--- a/packages/sync/src/output/prepare-generator-files/prepare-generator-file.unit.test.ts
+++ b/packages/sync/src/output/prepare-generator-files/prepare-generator-file.unit.test.ts
@@ -181,6 +181,38 @@ describe('prepareGeneratorFile', () => {
     });
   });
 
+  it('should not re-write a deleted file when content is unchanged', async () => {
+    const content = 'unchanged content';
+    const workingFiles = new Map<string, Buffer>();
+
+    const previousGeneratedFiles = new Map([
+      ['file.txt', Buffer.from(content)],
+    ]);
+
+    const mockPreviousPayload: PreviousGeneratedPayload = {
+      fileReader: createCodebaseReaderFromMemory(previousGeneratedFiles),
+      fileIdToRelativePathMap: new Map([[DEFAULT_FILE_ID, 'file.txt']]),
+    };
+
+    const result = await prepareGeneratorFile({
+      relativePath: 'file.txt',
+      data: createMockFileData({
+        contents: content,
+      }),
+      context: createMockContext({
+        previousWorkingCodebase: createCodebaseReaderFromMemory(workingFiles),
+        previousGeneratedPayload: mockPreviousPayload,
+      }),
+    });
+
+    expect(result).toEqual({
+      relativePath: 'file.txt',
+      previousRelativePath: undefined,
+      mergedContents: undefined,
+      generatedContents: Buffer.from(content),
+    });
+  });
+
   it('should handle JSON files with special merge algorithm', async () => {
     const workingFiles = new Map([
       ['config.json', Buffer.from('{"key": "original","other": "other"}')],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Patched behavior to ensure that files removed in previous versions are not unexpectedly regenerated if their content remains unchanged.

- **Refactor & Documentation**
  - Streamlined the file processing logic and updated descriptive text for improved clarity.

- **Tests**
  - Added a test to verify that deleted files with unchanged content are correctly handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->