### PR TITLE
feat: Upgrade Sentry to 9.10.1

### DIFF
--- a/.changeset/deep-baboons-leave.md
+++ b/.changeset/deep-baboons-leave.md
@@ -1,0 +1,9 @@
+---
+'@halfdomelabs/fastify-generators': patch
+'@halfdomelabs/react-generators': patch
+---
+
+Upgrade Sentry to 9.10.1
+
+See https://docs.sentry.io/platforms/javascript/migration/v8-to-v9/ for
+migration instructions

--- a/packages/fastify-generators/src/constants/fastify-packages.ts
+++ b/packages/fastify-generators/src/constants/fastify-packages.ts
@@ -64,11 +64,9 @@ export const FASTIFY_PACKAGES = {
   'ioredis-mock': '8.7.0',
 
   // Sentry
-  '@sentry/core': '8.55.0',
-  '@sentry/node': '8.55.0',
-  '@sentry/profiling-node': '8.55.0',
-
-  '@sentry/types': '8.55.0',
+  '@sentry/core': '9.10.1',
+  '@sentry/node': '9.10.1',
+  '@sentry/profiling-node': '9.10.1',
 
   // Validation
   zod: '3.24.1',

--- a/packages/fastify-generators/src/generators/core/fastify-sentry/index.ts
+++ b/packages/fastify-generators/src/generators/core/fastify-sentry/index.ts
@@ -145,7 +145,6 @@ export const fastifySentryGenerator = createGenerator({
         });
 
         node.addDevPackages({
-          '@sentry/types': FASTIFY_PACKAGES['@sentry/types'],
           '@types/lodash': FASTIFY_PACKAGES['@types/lodash'],
         });
 

--- a/packages/react-generators/src/constants/react-packages.ts
+++ b/packages/react-generators/src/constants/react-packages.ts
@@ -55,5 +55,5 @@ export const REACT_PACKAGES = {
   '@datadog/browser-logs': '4.19.1',
 
   // Sentry
-  '@sentry/react': '8.55.0',
+  '@sentry/react': '9.10.1',
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3496,8 +3496,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001695:
-    resolution: {integrity: sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==}
+  caniuse-lite@1.0.30001707:
+    resolution: {integrity: sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==}
 
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
@@ -8911,7 +8911,7 @@ snapshots:
   autoprefixer@10.4.20(postcss@8.4.38):
     dependencies:
       browserslist: 4.24.4
-      caniuse-lite: 1.0.30001695
+      caniuse-lite: 1.0.30001707
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -9007,7 +9007,7 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001695
+      caniuse-lite: 1.0.30001707
       electron-to-chromium: 1.5.86
       node-releases: 2.0.19
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
@@ -9060,7 +9060,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001695: {}
+  caniuse-lite@1.0.30001707: {}
 
   chai@5.2.0:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Introduced an upgrade guide with migration instructions for the Sentry integration.
  
- **Chores**
	- Upgraded Sentry dependencies to version 9.10.1 across backend and frontend components.
	- Removed outdated dependency references during the upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->