### PR TITLE
refactor: Remove baseUrl from tsconfig

### DIFF
--- a/.changeset/olive-guests-argue.md
+++ b/.changeset/olive-guests-argue.md
@@ -1,0 +1,6 @@
+---
+'@halfdomelabs/fastify-generators': patch
+'@halfdomelabs/react-generators': patch
+---
+
+Remove baseUrl from tsconfig.json since it is no longer necessary and ensure better consistency with imports

--- a/packages/code-morph/tsconfig.json
+++ b/packages/code-morph/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.cli.json",
   "compilerOptions": {
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]

--- a/packages/core-generators/src/generators/node/typescript/typescript.generator.ts
+++ b/packages/core-generators/src/generators/node/typescript/typescript.generator.ts
@@ -149,7 +149,6 @@ export const typescriptFileProvider =
 const DEFAULT_COMPILER_OPTIONS: TypescriptCompilerOptions = {
   outDir: 'dist',
   declaration: true,
-  baseUrl: './src',
   target: 'es2022',
   lib: ['es2023'],
   esModuleInterop: true,
@@ -214,9 +213,7 @@ export const typescriptGenerator = createGenerator({
             if (!paths && (baseUrl === './' || baseUrl === '.')) {
               // TODO: Support other source folders
               cachedPathEntries = [{ from: 'src', to: 'src' }];
-            } else if (!paths || !baseUrl) {
-              cachedPathEntries = [];
-            } else {
+            } else if (paths) {
               cachedPathEntries = Object.entries(paths).map(([key, value]) => {
                 if (value.length !== 1) {
                   throw new Error(
@@ -228,11 +225,13 @@ export const typescriptGenerator = createGenerator({
                 }
                 return {
                   from: path
-                    .join(baseUrl, value[0].replace(/\/\*$/, ''))
+                    .join(baseUrl ?? '.', value[0].replace(/\/\*$/, ''))
                     .replace(/^\./, ''),
                   to: key.slice(0, Math.max(0, key.length - 2)),
                 };
               });
+            } else {
+              cachedPathEntries = [];
             }
           }
 
@@ -416,3 +415,5 @@ export const typescriptGenerator = createGenerator({
     }),
   }),
 });
+
+export { type TypescriptCompilerOptions } from './compiler-types.js';

--- a/packages/core-generators/src/generators/node/typescript/typescript.generator.unit.test.ts
+++ b/packages/core-generators/src/generators/node/typescript/typescript.generator.unit.test.ts
@@ -14,7 +14,6 @@ describe('typescriptGenerator', () => {
     const typescriptBundle = typescriptGenerator({});
     const typescriptConfig = {
       compilerOptions: {
-        baseUrl: './src',
         paths: {
           '@src/*': ['src/*'],
         },

--- a/packages/core-generators/src/renderers/typescript/imports/ts-path-maps.ts
+++ b/packages/core-generators/src/renderers/typescript/imports/ts-path-maps.ts
@@ -10,7 +10,7 @@ import type { TsPathMapEntry } from './types.js';
  * @returns A list of TsPathMapEntry
  */
 export function generatePathMapEntries(
-  baseUrl: string,
+  baseUrl: string | undefined,
   paths: Record<string, string[]>,
 ): TsPathMapEntry[] {
   return Object.entries(paths).flatMap(([alias, targets]) => {
@@ -20,7 +20,7 @@ export function generatePathMapEntries(
     return [
       {
         from: alias,
-        to: `./${path.posix.join(baseUrl, targets[0]).replaceAll('\\', '/')}`,
+        to: `./${path.posix.join(baseUrl ?? '.', targets[0]).replaceAll('\\', '/')}`,
       },
     ];
   });

--- a/packages/core-generators/src/renderers/typescript/imports/ts-path-maps.unit.test.ts
+++ b/packages/core-generators/src/renderers/typescript/imports/ts-path-maps.unit.test.ts
@@ -25,6 +25,20 @@ describe('generatePathMapEntries', () => {
       { from: 'no-star', to: './src/something' },
     ]);
   });
+
+  it('should return a valid TsPathMapEntry list when baseUrl is undefined', () => {
+    // Arrange
+    const baseUrl = undefined;
+    const paths = {
+      '@src/*': ['./src/*'],
+    };
+
+    // Act
+    const result = generatePathMapEntries(baseUrl, paths);
+
+    // Assert
+    expect(result).toEqual([{ from: '@src/*', to: './src/*' }]);
+  });
 });
 
 describe('pathMapEntriesToRegexes', () => {

--- a/packages/core-generators/tsconfig.json
+++ b/packages/core-generators/tsconfig.json
@@ -2,10 +2,9 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.lib.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "noEmit": true,
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/create-project/tsconfig.json
+++ b/packages/create-project/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.cli.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]

--- a/packages/fastify-generators/src/generators/core/fastify/setup-fastify-typescript.ts
+++ b/packages/fastify-generators/src/generators/core/fastify/setup-fastify-typescript.ts
@@ -9,7 +9,6 @@ export const fastifyTypescriptTask = createGeneratorTask({
     typescriptSetup.compilerOptions.set({
       outDir: 'dist',
       declaration: true,
-      baseUrl: './',
       paths: {
         '@src/*': ['./src/*'],
       },

--- a/packages/fastify-generators/tsconfig.json
+++ b/packages/fastify-generators/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.lib.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/project-builder-cli/tsconfig.app.json
+++ b/packages/project-builder-cli/tsconfig.app.json
@@ -2,9 +2,8 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.cli.json",
   "compilerOptions": {
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]

--- a/packages/project-builder-cli/tsconfig.e2e.json
+++ b/packages/project-builder-cli/tsconfig.e2e.json
@@ -2,9 +2,8 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.cli.json",
   "compilerOptions": {
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["tests/**/*", "playwright.config.ts"]

--- a/packages/project-builder-lib/tsconfig.json
+++ b/packages/project-builder-lib/tsconfig.json
@@ -2,10 +2,9 @@
   "extends": "@halfdomelabs/tools/tsconfig.vite.lib.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "noEmit": true,
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     },
     "module": "Node16",
     "moduleResolution": "node16"

--- a/packages/project-builder-server/src/plugins/node-plugin-store.ts
+++ b/packages/project-builder-server/src/plugins/node-plugin-store.ts
@@ -1,10 +1,10 @@
 import type {
   PluginMetadataWithPaths,
+  PluginPlatformModule,
   PluginStore,
   SchemaParserContext,
 } from '@halfdomelabs/project-builder-lib';
 import type { Logger } from '@halfdomelabs/sync';
-import type { PluginPlatformModule } from 'node_modules/@halfdomelabs/project-builder-lib/dist/plugins/imports/types.js';
 
 import {
   adminCrudInputCompilerSpec,

--- a/packages/project-builder-server/tsconfig.json
+++ b/packages/project-builder-server/tsconfig.json
@@ -2,10 +2,9 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.lib.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "noEmit": true,
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]

--- a/packages/project-builder-test/tsconfig.json
+++ b/packages/project-builder-test/tsconfig.json
@@ -2,10 +2,9 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.lib.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "noEmit": true,
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]

--- a/packages/project-builder-web/tsconfig.json
+++ b/packages/project-builder-web/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "@halfdomelabs/tools/tsconfig.vite.web.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": "./",
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src"]

--- a/packages/react-generators/src/generators/core/react-typescript/react-typescript.generator.ts
+++ b/packages/react-generators/src/generators/core/react-typescript/react-typescript.generator.ts
@@ -44,7 +44,6 @@ export const reactTypescriptGenerator = createGenerator({
             noEmit: true,
 
             /* Paths */
-            baseUrl: './',
             paths: {
               '@src/*': ['./src/*'],
             },

--- a/packages/react-generators/tsconfig.json
+++ b/packages/react-generators/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.lib.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/sync/tsconfig.json
+++ b/packages/sync/tsconfig.json
@@ -2,10 +2,9 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.lib.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "noEmit": true,
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/tools/eslint-configs/typescript.js
+++ b/packages/tools/eslint-configs/typescript.js
@@ -144,6 +144,9 @@ export function generateTypescriptEslintConfig(options = []) {
         // Disallow importing dependencies that aren't explicitly listed in the package.json,
         // except for those explicitly allowed under `devDependencies` (e.g., test files)
         'import-x/no-extraneous-dependencies': ['error', { devDependencies }],
+
+        // Disallow import relative packages (e.g., `import '../other-package/foo'`)
+        'import-x/no-relative-packages': 'error',
       },
       settings: {
         'import-x/resolver-next': [createTypeScriptImportResolver()],

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "@halfdomelabs/tools/tsconfig.vite.lib.json",
   "compilerOptions": {
     "noEmit": true,
-    "baseUrl": "./",
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src", ".storybook/**/*"]

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -2,10 +2,9 @@
   "extends": "@halfdomelabs/tools/tsconfig.node.lib.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "noEmit": true,
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]

--- a/plugins/baseplate-plugin-storage/tsconfig.json
+++ b/plugins/baseplate-plugin-storage/tsconfig.json
@@ -2,10 +2,9 @@
   "extends": "@halfdomelabs/tools/tsconfig.vite.lib.json",
   "compilerOptions": {
     "outDir": "dist",
-    "baseUrl": ".",
     "noEmit": true,
     "paths": {
-      "@src/*": ["src/*"]
+      "@src/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the `baseUrl` compiler option from multiple TypeScript configurations across the project.
  - Updated path mappings for the `@src/*` alias to use explicit relative paths for improved consistency.
  - Adjusted internal logic to handle cases where `baseUrl` is undefined.

- **Style**
  - Standardized import paths to rely on public APIs rather than internal package structures.

- **Tests**
  - Updated test cases to reflect changes in TypeScript configuration and path resolution.

- **Chores**
  - Added a new ESLint rule to prevent importing relative packages using relative paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->