### PR TITLE
fix: Add VITE_* to passthrough vars in turbo.json

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,4 +27,5 @@ onlyBuiltDependencies:
   - '@prisma/engines'
   - cpu-features
   - esbuild
+  - protobufjs
   - ssh2

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalPassThroughEnv": ["PLAYWRIGHT_*"],
+  "globalPassThroughEnv": ["PLAYWRIGHT_*", "VITE_*"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workspace dependency settings.
  - Expanded build system configuration to pass through environment variables starting with "VITE_".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->