### PR TITLE
feat: Add ability to sort enums and keep order when generating Pothos enum

### DIFF
--- a/.changeset/mean-worms-worry.md
+++ b/.changeset/mean-worms-worry.md
@@ -1,0 +1,6 @@
+---
+'@halfdomelabs/project-builder-web': patch
+'@halfdomelabs/fastify-generators': patch
+---
+
+Add ability to sort enums and keep order when generating Pothos enum

--- a/packages/fastify-generators/src/generators/pothos/pothos-prisma-enum/pothos-prisma-enum.generator.ts
+++ b/packages/fastify-generators/src/generators/pothos/pothos-prisma-enum/pothos-prisma-enum.generator.ts
@@ -35,6 +35,8 @@ export const pothosPrismaEnumGenerator = createGenerator({
               Object.fromEntries(
                 enumBlock.values.map((value) => [value.name, '{}']),
               ),
+              // use sort from prisma output
+              { disableSort: true },
             )}
           })
         `;

--- a/packages/project-builder-web/src/pages/data/enums/edit/sections/EnumValuesSection.tsx
+++ b/packages/project-builder-web/src/pages/data/enums/edit/sections/EnumValuesSection.tsx
@@ -9,10 +9,11 @@ import {
   Label,
   SectionList,
 } from '@halfdomelabs/ui-components';
+import clsx from 'clsx';
 import { useFieldArray, useWatch } from 'react-hook-form';
 import { MdDeleteOutline } from 'react-icons/md';
-import { Fragment } from 'react/jsx-runtime';
 
+import { SortableList } from '@src/components';
 import { underscoreToTitleCase } from '@src/utils/casing';
 
 export function EnumValuesSection({
@@ -26,12 +27,47 @@ export function EnumValuesSection({
     fields: valueFields,
     remove: removeValue,
     append: appendValue,
+    move: sortValues,
   } = useFieldArray({
     control,
     name: 'values',
   });
 
   const values = useWatch({ control, name: 'values' });
+
+  const gridClassNames =
+    'grid grid-cols-[repeat(2,minmax(130px,1fr))_80px] gap-3';
+
+  const valueListItems = valueFields.map((field, i) => ({
+    id: field.id,
+    element: (
+      <div className={gridClassNames}>
+        <InputField.Controller control={control} name={`values.${i}.name`} />
+        <InputField.Controller
+          control={control}
+          name={`values.${i}.friendlyName`}
+          onFocus={() => {
+            if (!values[i].friendlyName && values[i].name) {
+              setValue(
+                `values.${i}.friendlyName`,
+                underscoreToTitleCase(values[i].name),
+              );
+            }
+          }}
+        />
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => {
+            removeValue(i);
+          }}
+        >
+          <Button.Icon icon={MdDeleteOutline} />
+          <div className="sr-only">Delete Enum</div>
+        </Button>
+      </div>
+    ),
+  }));
 
   return (
     <SectionList.Section>
@@ -42,41 +78,25 @@ export function EnumValuesSection({
         </SectionList.SectionDescription>
       </SectionList.SectionHeader>
       <SectionList.SectionContent className="space-y-4">
-        <div className="grid grid-cols-3 items-center gap-x-4 gap-y-2">
-          <Label className="mb-2">Value Name, e.g. ACTIVE</Label>
-          <Label className="col-span-2 mb-2">
-            Value Friendly Name, e.g. Active
-          </Label>
-          {valueFields.map((field, i) => (
-            <Fragment key={field.id}>
-              <InputField.Controller
-                control={control}
-                name={`values.${i}.name`}
-              />
-              <InputField.Controller
-                control={control}
-                name={`values.${i}.friendlyName`}
-                onFocus={() => {
-                  if (!values[i].friendlyName && values[i].name) {
-                    setValue(
-                      `values.${i}.friendlyName`,
-                      underscoreToTitleCase(values[i].name),
-                    );
-                  }
-                }}
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => {
-                  removeValue(i);
-                }}
-              >
-                <Button.Icon icon={MdDeleteOutline} />
-                <div className="sr-only">Delete Enum</div>
-              </Button>
-            </Fragment>
-          ))}
+        <div className="space-y-2">
+          <div
+            className={clsx(
+              gridClassNames,
+              // account for handle in sortable list
+              'pl-12',
+            )}
+          >
+            <Label>Value Name, e.g. ACTIVE</Label>
+            <Label>Value Friendly Name, e.g. Active</Label>
+            <div />
+          </div>
+          {valueFields.length === 0 ? (
+            <p className="pt-4 text-style-muted">
+              Add some values to get started
+            </p>
+          ) : (
+            <SortableList listItems={valueListItems} sortItems={sortValues} />
+          )}
         </div>
         <Button
           size="sm"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for sorting and preserving the order of enum values during generation, ensuring enums maintain their intended sequence.

- **Refactor**
  - Improved the enum values editing interface with a drag-and-drop sortable list for easier reordering and enhanced usability. 
  - Updated styling for better alignment and consistency in the enum editing section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->