### PR TITLE
refactor: Enable the import-x/consistent-type-specifier-style rule to clean up type imports

### DIFF
--- a/.changeset/busy-spoons-yawn.md
+++ b/.changeset/busy-spoons-yawn.md
@@ -1,0 +1,17 @@
+---
+'@baseplate-dev/project-builder-server': patch
+'@baseplate-dev/project-builder-test': patch
+'@baseplate-dev/project-builder-cli': patch
+'@baseplate-dev/project-builder-lib': patch
+'@baseplate-dev/project-builder-web': patch
+'@baseplate-dev/fastify-generators': patch
+'@baseplate-dev/react-generators': patch
+'@baseplate-dev/core-generators': patch
+'@baseplate-dev/ui-components': patch
+'@baseplate-dev/code-morph': patch
+'@baseplate-dev/tools': patch
+'@baseplate-dev/utils': patch
+'@baseplate-dev/sync': patch
+---
+
+Enable the import-x/consistent-type-specifier-style rule to clean up type imports

--- a/packages/code-morph/src/constants/ts-morph-settings.ts
+++ b/packages/code-morph/src/constants/ts-morph-settings.ts
@@ -1,8 +1,6 @@
-import {
-  IndentationText,
-  type ManipulationSettings,
-  QuoteKind,
-} from 'ts-morph';
+import type { ManipulationSettings } from 'ts-morph';
+
+import { IndentationText, QuoteKind } from 'ts-morph';
 
 export const TS_MORPH_MANIPULATION_SETTINGS: Partial<ManipulationSettings> = {
   indentationText: IndentationText.TwoSpaces,

--- a/packages/code-morph/src/morphers/utils/imports.ts
+++ b/packages/code-morph/src/morphers/utils/imports.ts
@@ -1,9 +1,10 @@
-import {
-  type ImportDeclarationStructure,
-  Node,
-  type OptionalKind,
-  type SourceFile,
+import type {
+  ImportDeclarationStructure,
+  OptionalKind,
+  SourceFile,
 } from 'ts-morph';
+
+import { Node } from 'ts-morph';
 
 /**
  * Add an import declaration to a source file to the first line after comments.

--- a/packages/code-morph/src/morphers/utils/move-file.ts
+++ b/packages/code-morph/src/morphers/utils/move-file.ts
@@ -1,5 +1,7 @@
+import type { SourceFile } from 'ts-morph';
+
 import path from 'node:path';
-import { ModuleResolutionKind, type SourceFile } from 'ts-morph';
+import { ModuleResolutionKind } from 'ts-morph';
 
 import type { MorpherContext } from '#src/types.js';
 

--- a/packages/core-generators/src/generators/node/vitest/vitest.generator.ts
+++ b/packages/core-generators/src/generators/node/vitest/vitest.generator.ts
@@ -20,9 +20,10 @@ const descriptorSchema = z.object({});
 
 import { stringifyPrettyStable } from '@baseplate-dev/utils';
 
+import type { TsCodeFragment } from '#src/renderers/index.js';
+
 import {
   tsCodeFragment,
-  type TsCodeFragment,
   TsCodeUtils,
   tsImportBuilder,
 } from '#src/renderers/index.js';

--- a/packages/core-generators/src/renderers/typescript/actions/render-ts-template-group-action.ts
+++ b/packages/core-generators/src/renderers/typescript/actions/render-ts-template-group-action.ts
@@ -1,9 +1,10 @@
-import {
-  type BuilderAction,
-  normalizePathToProjectPath,
-  type ProviderType,
-  type WriteFileOptions,
+import type {
+  BuilderAction,
+  ProviderType,
+  WriteFileOptions,
 } from '@baseplate-dev/sync';
+
+import { normalizePathToProjectPath } from '@baseplate-dev/sync';
 import { enhanceErrorWithContext } from '@baseplate-dev/utils';
 import { mapValues } from 'es-toolkit';
 import path from 'node:path';

--- a/packages/core-generators/src/renderers/typescript/extractor/write-ts-project-exports.ts
+++ b/packages/core-generators/src/renderers/typescript/extractor/write-ts-project-exports.ts
@@ -1,7 +1,6 @@
-import {
-  parseGeneratorName,
-  type TemplateFileExtractorFile,
-} from '@baseplate-dev/sync';
+import type { TemplateFileExtractorFile } from '@baseplate-dev/sync';
+
+import { parseGeneratorName } from '@baseplate-dev/sync';
 import { quot } from '@baseplate-dev/utils';
 import { getCommonPathPrefix } from '@baseplate-dev/utils/node';
 import { camelCase, pascalCase } from 'change-case';

--- a/packages/core-generators/src/renderers/typescript/imports/ts-morph-operations.ts
+++ b/packages/core-generators/src/renderers/typescript/imports/ts-morph-operations.ts
@@ -1,9 +1,6 @@
-import {
-  type CodeBlockWriter,
-  type ImportDeclaration,
-  Node,
-  type SourceFile,
-} from 'ts-morph';
+import type { CodeBlockWriter, ImportDeclaration, SourceFile } from 'ts-morph';
+
+import { Node } from 'ts-morph';
 
 import type { TsImportDeclaration } from './types.js';
 

--- a/packages/fastify-generators/src/generators/core/app-module-setup/app-module-setup.generator.ts
+++ b/packages/fastify-generators/src/generators/core/app-module-setup/app-module-setup.generator.ts
@@ -1,6 +1,7 @@
+import type { TsCodeFragment } from '@baseplate-dev/core-generators';
+
 import {
   projectScope,
-  type TsCodeFragment,
   TsCodeUtils,
   typescriptFileProvider,
 } from '@baseplate-dev/core-generators';

--- a/packages/project-builder-cli/tests/fixtures/server-fixture.test-helper.ts
+++ b/packages/project-builder-cli/tests/fixtures/server-fixture.test-helper.ts
@@ -1,11 +1,9 @@
 /* eslint-disable no-empty-pattern -- required by Playwright */
+import type { ProjectDefinition } from '@baseplate-dev/project-builder-lib';
 import type { BuilderServiceManager } from '@baseplate-dev/project-builder-server';
 import type { FastifyInstance } from 'fastify';
 
-import {
-  getLatestMigrationVersion,
-  type ProjectDefinition,
-} from '@baseplate-dev/project-builder-lib';
+import { getLatestMigrationVersion } from '@baseplate-dev/project-builder-lib';
 import { stringifyPrettyStable } from '@baseplate-dev/utils';
 import { test as base } from '@playwright/test';
 import fs from 'node:fs/promises';

--- a/packages/project-builder-lib/src/definition/plugins/plugin-utils.ts
+++ b/packages/project-builder-lib/src/definition/plugins/plugin-utils.ts
@@ -1,13 +1,14 @@
-import {
-  pluginConfigSpec,
-  type PluginImplementationStore,
-  type PluginMetadataWithPaths,
+import type {
+  PluginImplementationStore,
+  PluginMetadataWithPaths,
 } from '#src/plugins/index.js';
-import {
-  type BasePluginDefinition,
-  pluginEntityType,
-  type ProjectDefinition,
+import type {
+  BasePluginDefinition,
+  ProjectDefinition,
 } from '#src/schema/index.js';
+
+import { pluginConfigSpec } from '#src/plugins/index.js';
+import { pluginEntityType } from '#src/schema/index.js';
 
 function byId(
   projectDefinition: ProjectDefinition,

--- a/packages/project-builder-lib/src/references/parse-schema-with-references.ts
+++ b/packages/project-builder-lib/src/references/parse-schema-with-references.ts
@@ -1,12 +1,10 @@
 import type { z } from 'zod';
 
+import type { ResolveZodRefPayloadNamesOptions } from './resolve-zod-ref-payload-names.js';
 import type { ResolvedZodRefPayload } from './types.js';
 
 import { ZodRefWrapper } from './ref-builder.js';
-import {
-  resolveZodRefPayloadNames,
-  type ResolveZodRefPayloadNamesOptions,
-} from './resolve-zod-ref-payload-names.js';
+import { resolveZodRefPayloadNames } from './resolve-zod-ref-payload-names.js';
 
 /**
  * Parses a schema with references.

--- a/packages/project-builder-lib/src/web/components/ModelMergerResultAlert.tsx
+++ b/packages/project-builder-lib/src/web/components/ModelMergerResultAlert.tsx
@@ -1,15 +1,15 @@
+import type { ReactElement } from 'react';
+
 import {
   Alert,
   AlertDescription,
   AlertTitle,
 } from '@baseplate-dev/ui-components';
 import { capitalize } from 'es-toolkit';
-import { type ReactElement } from 'react';
 
-import {
-  modelMergerDefinitionDiffConfig,
-  type ModelMergerModelDiffResult,
-} from '#src/tools/index.js';
+import type { ModelMergerModelDiffResult } from '#src/tools/index.js';
+
+import { modelMergerDefinitionDiffConfig } from '#src/tools/index.js';
 
 interface Props {
   pendingModelChanges: Record<string, ModelMergerModelDiffResult | undefined>;

--- a/packages/project-builder-lib/src/web/hooks/useBlockUnsavedChangesNavigate.ts
+++ b/packages/project-builder-lib/src/web/hooks/useBlockUnsavedChangesNavigate.ts
@@ -1,7 +1,9 @@
+import type { Control, FieldValues } from 'react-hook-form';
+
 import { toast } from '@baseplate-dev/ui-components';
 import { flattenObject } from 'es-toolkit';
 import { useEffect, useRef } from 'react';
-import { type Control, type FieldValues, useFormState } from 'react-hook-form';
+import { useFormState } from 'react-hook-form';
 
 import { useBlockerDialog } from './useBlockerDialog.js';
 

--- a/packages/project-builder-server/src/compiler/admin/crud/index.ts
+++ b/packages/project-builder-server/src/compiler/admin/crud/index.ts
@@ -3,6 +3,7 @@ import type {
   AdminCrudEmbeddedFormConfig,
   AdminCrudSectionConfig,
 } from '@baseplate-dev/project-builder-lib';
+import type { GeneratorBundle } from '@baseplate-dev/sync';
 
 import { ModelUtils } from '@baseplate-dev/project-builder-lib';
 import {
@@ -14,7 +15,7 @@ import {
   adminCrudSectionGenerator,
   reactRoutesGenerator,
 } from '@baseplate-dev/react-generators';
-import { type GeneratorBundle, makeIdSafe } from '@baseplate-dev/sync';
+import { makeIdSafe } from '@baseplate-dev/sync';
 import inflection from 'inflection';
 
 import type { AppEntryBuilder } from '#src/compiler/app-entry-builder.js';

--- a/packages/project-builder-server/src/compiler/admin/crud/inputs.ts
+++ b/packages/project-builder-server/src/compiler/admin/crud/inputs.ts
@@ -10,6 +10,7 @@ import type {
   AdminCrudTextInputConfig,
   ModelScalarFieldConfig,
 } from '@baseplate-dev/project-builder-lib';
+import type { GeneratorBundle } from '@baseplate-dev/sync';
 
 import {
   adminCrudInputCompilerSpec,
@@ -24,7 +25,7 @@ import {
   adminCrudPasswordInputGenerator,
   adminCrudTextInputGenerator,
 } from '@baseplate-dev/react-generators';
-import { type GeneratorBundle, makeIdSafe } from '@baseplate-dev/sync';
+import { makeIdSafe } from '@baseplate-dev/sync';
 
 import type { AppEntryBuilder } from '#src/compiler/app-entry-builder.js';
 

--- a/packages/project-builder-server/src/server/plugin.ts
+++ b/packages/project-builder-server/src/server/plugin.ts
@@ -8,10 +8,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod';
 
+import type { AppRouter } from '#src/api/index.js';
 import type { BaseplateUserConfig } from '#src/user-config/user-config-schema.js';
 
 import { createContextBuilder } from '#src/api/context.js';
-import { appRouter, type AppRouter } from '#src/api/index.js';
+import { appRouter } from '#src/api/index.js';
 import { pathSafeJoin } from '#src/utils/paths.js';
 
 import type { BuilderServiceManager } from './builder-service-manager.js';

--- a/packages/project-builder-server/src/sync/build-project.ts
+++ b/packages/project-builder-server/src/sync/build-project.ts
@@ -2,13 +2,14 @@ import type {
   ProjectDefinition,
   SchemaParserContext,
 } from '@baseplate-dev/project-builder-lib';
+import type { Logger } from '@baseplate-dev/sync';
 
 import {
   createPluginImplementationStore,
   runPluginMigrations,
   runSchemaMigrations,
 } from '@baseplate-dev/project-builder-lib';
-import { CancelledSyncError, type Logger } from '@baseplate-dev/sync';
+import { CancelledSyncError } from '@baseplate-dev/sync';
 import {
   enhanceErrorWithContext,
   hashWithSHA256,

--- a/packages/project-builder-server/src/sync/sync-metadata-controller.ts
+++ b/packages/project-builder-server/src/sync/sync-metadata-controller.ts
@@ -8,16 +8,14 @@ import { watch } from 'chokidar';
 import { isEqual, throttle } from 'es-toolkit';
 import path from 'node:path';
 
+import type { PackageSyncInfo, SyncMetadata } from './sync-metadata.js';
+
 import {
   readSyncMetadata,
   SYNC_METADATA_PATH,
   writeSyncMetadata,
 } from './sync-metadata-service.js';
-import {
-  INITIAL_SYNC_METADATA,
-  type PackageSyncInfo,
-  type SyncMetadata,
-} from './sync-metadata.js';
+import { INITIAL_SYNC_METADATA } from './sync-metadata.js';
 
 /**
  * Controller for getting updates about the latest sync metadata.

--- a/packages/project-builder-server/src/sync/sync-metadata-controller.unit.test.ts
+++ b/packages/project-builder-server/src/sync/sync-metadata-controller.unit.test.ts
@@ -3,6 +3,8 @@ import type { TestLogger } from '@baseplate-dev/sync';
 import { createTestLogger } from '@baseplate-dev/sync';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { PackageSyncInfo, SyncMetadata } from './sync-metadata.js';
+
 import {
   emitMockFsWatcherEvent,
   getMockFsWatchedFiles,
@@ -14,11 +16,7 @@ import {
   readSyncMetadata,
   writeSyncMetadata,
 } from './sync-metadata-service.js';
-import {
-  INITIAL_SYNC_METADATA,
-  type PackageSyncInfo,
-  type SyncMetadata,
-} from './sync-metadata.js';
+import { INITIAL_SYNC_METADATA } from './sync-metadata.js';
 
 vi.mock('./sync-metadata-service.js');
 vi.mock('chokidar', () => ({

--- a/packages/project-builder-test/src/commands/serve.ts
+++ b/packages/project-builder-test/src/commands/serve.ts
@@ -1,10 +1,8 @@
+import type { ProjectDefinitionInput } from '@baseplate-dev/project-builder-lib';
 import type { Command } from 'commander';
 
 import { getDefaultPlugins } from '@baseplate-dev/project-builder-common';
-import {
-  getLatestMigrationVersion,
-  type ProjectDefinitionInput,
-} from '@baseplate-dev/project-builder-lib';
+import { getLatestMigrationVersion } from '@baseplate-dev/project-builder-lib';
 import {
   BuilderServiceManager,
   DEFAULT_SERVER_PORT,

--- a/packages/project-builder-web/src/pages/apps/edit/admin/crud/AdminCrudEmbeddedForm.tsx
+++ b/packages/project-builder-web/src/pages/apps/edit/admin/crud/AdminCrudEmbeddedForm.tsx
@@ -1,5 +1,6 @@
 import type { AdminCrudEmbeddedFormConfigInput } from '@baseplate-dev/project-builder-lib';
 import type React from 'react';
+import type { Control, UseFormReturn } from 'react-hook-form';
 
 import {
   adminCrudEmbeddedFormSchema,
@@ -21,7 +22,7 @@ import {
 } from '@baseplate-dev/ui-components';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useId } from 'react';
-import { type Control, useForm, type UseFormReturn } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 
 import type {
   EmbeddedListFormProps,

--- a/packages/project-builder-web/src/pages/data/models/edit/[id]/_components/graphql/GraphQLMutationsSection.tsx
+++ b/packages/project-builder-web/src/pages/data/models/edit/[id]/_components/graphql/GraphQLMutationsSection.tsx
@@ -1,10 +1,8 @@
+import type { ModelConfigInput } from '@baseplate-dev/project-builder-lib';
 import type React from 'react';
 import type { Control } from 'react-hook-form';
 
-import {
-  authConfigSpec,
-  type ModelConfigInput,
-} from '@baseplate-dev/project-builder-lib';
+import { authConfigSpec } from '@baseplate-dev/project-builder-lib';
 import { useProjectDefinition } from '@baseplate-dev/project-builder-lib/web';
 import {
   Alert,

--- a/packages/project-builder-web/src/pages/data/models/edit/[id]/_components/graphql/GraphQLQueriesSection.tsx
+++ b/packages/project-builder-web/src/pages/data/models/edit/[id]/_components/graphql/GraphQLQueriesSection.tsx
@@ -1,10 +1,8 @@
+import type { ModelConfigInput } from '@baseplate-dev/project-builder-lib';
 import type React from 'react';
 import type { Control } from 'react-hook-form';
 
-import {
-  authConfigSpec,
-  type ModelConfigInput,
-} from '@baseplate-dev/project-builder-lib';
+import { authConfigSpec } from '@baseplate-dev/project-builder-lib';
 import { useProjectDefinition } from '@baseplate-dev/project-builder-lib/web';
 import {
   Alert,

--- a/packages/react-generators/src/generators/auth/_providers/auth-components.ts
+++ b/packages/react-generators/src/generators/auth/_providers/auth-components.ts
@@ -1,7 +1,6 @@
-import {
-  createTsImportMapSchema,
-  type TsImportMapProviderFromSchema,
-} from '@baseplate-dev/core-generators';
+import type { TsImportMapProviderFromSchema } from '@baseplate-dev/core-generators';
+
+import { createTsImportMapSchema } from '@baseplate-dev/core-generators';
 import { createReadOnlyProviderType } from '@baseplate-dev/sync';
 
 export const authComponentsImportsSchema = createTsImportMapSchema({

--- a/packages/react-generators/src/generators/auth/_providers/auth-hooks.ts
+++ b/packages/react-generators/src/generators/auth/_providers/auth-hooks.ts
@@ -1,7 +1,6 @@
-import {
-  createTsImportMapSchema,
-  type TsImportMapProviderFromSchema,
-} from '@baseplate-dev/core-generators';
+import type { TsImportMapProviderFromSchema } from '@baseplate-dev/core-generators';
+
+import { createTsImportMapSchema } from '@baseplate-dev/core-generators';
 import { createReadOnlyProviderType } from '@baseplate-dev/sync';
 
 export const authHooksImportsSchema = createTsImportMapSchema({

--- a/packages/sync/src/generators/generators.unit.test.ts
+++ b/packages/sync/src/generators/generators.unit.test.ts
@@ -4,12 +4,13 @@ import type { GeneratorTaskOutputBuilder } from '#src/output/generator-task-outp
 
 import { createProviderType } from '#src/providers/index.js';
 
-import {
-  createGeneratorTask,
-  type InferDependencyProviderMap,
-  type InferExportProviderMap,
-  type ProviderExportMap,
+import type {
+  InferDependencyProviderMap,
+  InferExportProviderMap,
+  ProviderExportMap,
 } from './generators.js';
+
+import { createGeneratorTask } from './generators.js';
 
 describe('generators type definitions', () => {
   it('should correctly infer provider maps from export and dependency maps', () => {

--- a/packages/sync/src/output/post-write-commands/filter-commands.unit.test.ts
+++ b/packages/sync/src/output/post-write-commands/filter-commands.unit.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import type { PostWriteCommand } from './types.js';
+
 import { filterPostWriteCommands } from './filter-commands.js';
-import { type PostWriteCommand } from './types.js';
 
 describe('filterPostWriteCommands', () => {
   it('should include commands without onlyIfChanged option', () => {

--- a/packages/sync/src/output/post-write-commands/run-commands.ts
+++ b/packages/sync/src/output/post-write-commands/run-commands.ts
@@ -6,7 +6,7 @@ import type { Logger } from '#src/utils/evented-logger.js';
 
 import { executeCommand } from '#src/utils/exec.js';
 
-import { type PostWriteCommand } from './types.js';
+import type { PostWriteCommand } from './types.js';
 
 const COMMAND_TIMEOUT_MILLIS = ms('5m');
 

--- a/packages/sync/src/output/post-write-commands/run-commands.unit.test.ts
+++ b/packages/sync/src/output/post-write-commands/run-commands.unit.test.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { executeCommand } from '#src/utils/exec.js';
 
+import type { PostWriteCommand } from './types.js';
+
 import { runPostWriteCommands } from './run-commands.js';
-import { type PostWriteCommand } from './types.js';
 
 // Mock executeCommand
 vi.mock('#src/utils/exec.js', () => ({

--- a/packages/sync/src/output/post-write-commands/sort-commands.ts
+++ b/packages/sync/src/output/post-write-commands/sort-commands.ts
@@ -1,6 +1,8 @@
 import { sortBy } from 'es-toolkit';
 
-import { POST_WRITE_COMMAND_PRIORITY, type PostWriteCommand } from './types.js';
+import type { PostWriteCommand } from './types.js';
+
+import { POST_WRITE_COMMAND_PRIORITY } from './types.js';
 
 /**
  * Sort post-write commands by priority

--- a/packages/sync/src/output/post-write-commands/sort-commands.unit.test.ts
+++ b/packages/sync/src/output/post-write-commands/sort-commands.unit.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import type { PostWriteCommand } from './types.js';
+
 import { sortPostWriteCommands } from './sort-commands.js';
-import { type PostWriteCommand } from './types.js';
 
 describe('sortPostWriteCommands', () => {
   it('should sort commands by priority', () => {

--- a/packages/sync/src/templates/raw-template/render-raw-template-action.ts
+++ b/packages/sync/src/templates/raw-template/render-raw-template-action.ts
@@ -1,12 +1,10 @@
 import type { BuilderAction } from '#src/output/builder-action.js';
 import type { WriteFileOptions } from '#src/output/generator-task-output.js';
 
+import type { RawTemplateFile, RawTemplateFileMetadata } from './types.js';
+
 import { readTemplateFileSourceBuffer } from '../utils/index.js';
-import {
-  RAW_TEMPLATE_TYPE,
-  type RawTemplateFile,
-  type RawTemplateFileMetadata,
-} from './types.js';
+import { RAW_TEMPLATE_TYPE } from './types.js';
 
 interface RenderRawTemplateFileActionInput {
   template: RawTemplateFile;

--- a/packages/sync/src/templates/utils/formatter.ts
+++ b/packages/sync/src/templates/utils/formatter.ts
@@ -1,9 +1,6 @@
-import {
-  format,
-  type Options,
-  resolveConfig,
-  resolveConfigFile,
-} from 'prettier';
+import type { Options } from 'prettier';
+
+import { format, resolveConfig, resolveConfigFile } from 'prettier';
 
 const ALLOWED_EXTENSIONS = new Set([
   'ts',

--- a/packages/sync/src/test-runners/test-runner.ts
+++ b/packages/sync/src/test-runners/test-runner.ts
@@ -7,15 +7,13 @@ import type {
   ProviderDependencyMap,
   ProviderExportMap,
 } from '#src/generators/generators.js';
+import type { GeneratorTaskOutput } from '#src/output/generator-task-output.js';
 import type {
   PostWriteCommand,
   TemplateMetadataOptions,
 } from '#src/output/index.js';
 
-import {
-  type GeneratorTaskOutput,
-  GeneratorTaskOutputBuilder,
-} from '#src/output/generator-task-output.js';
+import { GeneratorTaskOutputBuilder } from '#src/output/generator-task-output.js';
 
 interface TaskTestRunnerResult<
   ExportMap extends ProviderExportMap | undefined,

--- a/packages/sync/src/utils/create-config-provider-task-with-info.ts
+++ b/packages/sync/src/utils/create-config-provider-task-with-info.ts
@@ -1,18 +1,19 @@
-import {
-  createFieldMap,
-  type FieldMapSchema,
-  type FieldMapSchemaBuilder,
-  type FieldMapValues,
+import type {
+  FieldMapSchema,
+  FieldMapSchemaBuilder,
+  FieldMapValues,
 } from '@baseplate-dev/utils';
+
+import { createFieldMap } from '@baseplate-dev/utils';
 
 import type { GeneratorTask } from '#src/generators/generators.js';
 import type { ProviderExportScope } from '#src/providers/export-scopes.js';
+import type { ProviderType } from '#src/providers/providers.js';
 
 import { createGeneratorTask } from '#src/generators/generators.js';
 import {
   createProviderType,
   createReadOnlyProviderType,
-  type ProviderType,
 } from '#src/providers/providers.js';
 
 /**

--- a/packages/sync/src/utils/create-config-provider-task.ts
+++ b/packages/sync/src/utils/create-config-provider-task.ts
@@ -5,16 +5,14 @@ import type {
   FieldMapValues,
 } from '@baseplate-dev/utils';
 
+import type { GeneratorTask } from '#src/generators/generators.js';
 import type { ProviderExportScope } from '#src/providers/export-scopes.js';
+import type { ProviderType } from '#src/providers/providers.js';
 
-import {
-  createGeneratorTask,
-  type GeneratorTask,
-} from '#src/generators/generators.js';
+import { createGeneratorTask } from '#src/generators/generators.js';
 import {
   createProviderType,
   createReadOnlyProviderType,
-  type ProviderType,
 } from '#src/providers/providers.js';
 
 import { createConfigFieldMap } from './create-config-field-map.js';

--- a/packages/tools/eslint-configs/typescript.js
+++ b/packages/tools/eslint-configs/typescript.js
@@ -138,6 +138,12 @@ export function generateTypescriptEslintConfig(options = []) {
 
         // Disallow import relative packages (e.g., `import '../other-package/foo'`)
         'import-x/no-relative-packages': 'error',
+
+        // Use top-level type imports
+        'import-x/consistent-type-specifier-style': [
+          'error',
+          'prefer-top-level',
+        ],
       },
       languageOptions: {
         ecmaVersion: 2022,

--- a/packages/ui-components/src/components/Alert/Alert.tsx
+++ b/packages/ui-components/src/components/Alert/Alert.tsx
@@ -1,6 +1,7 @@
+import type { VariantProps } from 'class-variance-authority';
 import type * as React from 'react';
 
-import { cva, type VariantProps } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
 
 import { cn } from '#src/utils/index.js';
 

--- a/packages/ui-components/src/components/Badge/Badge.tsx
+++ b/packages/ui-components/src/components/Badge/Badge.tsx
@@ -1,7 +1,8 @@
+import type { VariantProps } from 'class-variance-authority';
 import type React from 'react';
 
 import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
 
 import { cn } from '#src/utils/index.js';
 

--- a/packages/ui-components/src/components/Button/Button.tsx
+++ b/packages/ui-components/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
+import type { VariantProps } from 'class-variance-authority';
 import type React from 'react';
 
 import { Slot } from '@radix-ui/react-slot';
-import { type VariantProps } from 'class-variance-authority';
 
 import { buttonVariants } from '#src/styles/index.js';
 import { cn } from '#src/utils/index.js';

--- a/packages/ui-components/src/utils/cn.ts
+++ b/packages/ui-components/src/utils/cn.ts
@@ -1,4 +1,6 @@
-import { type ClassValue, clsx } from 'clsx';
+import type { ClassValue } from 'clsx';
+
+import { clsx } from 'clsx';
 
 export function cn(...inputs: ClassValue[]): string {
   return clsx(inputs);

--- a/packages/utils/src/fs/read-json-with-schema.ts
+++ b/packages/utils/src/fs/read-json-with-schema.ts
@@ -1,5 +1,7 @@
+import type { z } from 'zod';
+
 import fs from 'node:fs/promises';
-import { type z, ZodError } from 'zod';
+import { ZodError } from 'zod';
 
 /**
  * Reads a file, parses its content as JSON, and validates it against a Zod schema.

--- a/packages/utils/src/validators/transform-with-dynamic-schema.ts
+++ b/packages/utils/src/validators/transform-with-dynamic-schema.ts
@@ -1,4 +1,6 @@
-import { type RefinementCtx, z, type ZodTypeAny } from 'zod';
+import type { RefinementCtx, ZodTypeAny } from 'zod';
+
+import { z } from 'zod';
 
 /**
  * Transforms a value using a dynamic schema and forwards any issues to transform context.

--- a/packages/utils/src/validators/transform-with-dynamic-schema.unit.test.ts
+++ b/packages/utils/src/validators/transform-with-dynamic-schema.unit.test.ts
@@ -1,5 +1,7 @@
+import type { RefinementCtx, ZodInvalidTypeIssue } from 'zod';
+
 import { describe, expect, it, vi } from 'vitest';
-import { type RefinementCtx, z, type ZodInvalidTypeIssue } from 'zod';
+import { z } from 'zod';
 
 import { transformWithDynamicSchema } from './transform-with-dynamic-schema.js';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved consistency in type import style across the codebase, ensuring type-only imports are clearly separated from value imports in all packages.

- **Chores**
  - Enabled a new linting rule to enforce consistent type import declarations in TypeScript code throughout the project. 

No changes to application features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->