### PR TITLE
refactor: Rename Uid methods to key methods

### DIFF
--- a/.changeset/empty-sheep-tell.md
+++ b/.changeset/empty-sheep-tell.md
@@ -1,0 +1,9 @@
+---
+'@baseplate-dev/project-builder-server': patch
+'@baseplate-dev/project-builder-cli': patch
+'@baseplate-dev/project-builder-lib': patch
+'@baseplate-dev/project-builder-web': patch
+'@baseplate-dev/utils': patch
+---
+
+Rename entity UID to Key to make it clearer what is happening

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:affected": "turbo run build --affected",
     "changesets:check": "node --experimental-strip-types ./scripts/check-changesets.ts",
     "clean": "turbo run clean",
-    "dev:serve": "pnpm --filter @baseplate-dev/project-builder-cli dev:serve",
+    "dev:serve": "pnpm --color --reporter-hide-prefix --filter @baseplate-dev/project-builder-cli --filter @baseplate-dev/project-builder-web --parallel dev:serve",
     "extract:templates": "pnpm --filter @baseplate-dev/project-builder-cli extract:templates",
     "preinstall": "npx only-allow pnpm",
     "knip": "knip",

--- a/packages/project-builder-cli/tests/sync.spec.ts
+++ b/packages/project-builder-cli/tests/sync.spec.ts
@@ -12,10 +12,10 @@ import {
 } from './fixtures/server-fixture.test-helper.js';
 
 test('can sync a minimal project', async ({ page, addProject }) => {
-  const modelId = modelEntityType.fromUid('test-model');
-  const featureId = featureEntityType.fromUid('test-feature');
-  const appId = appEntityType.fromUid('test-app');
-  const fieldId = modelScalarFieldEntityType.fromUid('test-field');
+  const modelId = modelEntityType.idFromKey('test-model');
+  const featureId = featureEntityType.idFromKey('test-feature');
+  const appId = appEntityType.idFromKey('test-app');
+  const fieldId = modelScalarFieldEntityType.idFromKey('test-field');
 
   const { makeUrl } = await addProject({
     ...getInitializedTestProjectDefinition(),

--- a/packages/project-builder-lib/src/definition/plugins/plugin-utils.ts
+++ b/packages/project-builder-lib/src/definition/plugins/plugin-utils.ts
@@ -14,7 +14,7 @@ function byId(
   projectDefinition: ProjectDefinition,
   id: string,
 ): BasePluginDefinition | null {
-  const pluginEntityId = pluginEntityType.fromUid(id);
+  const pluginEntityId = pluginEntityType.idFromKey(id);
   const plugin = projectDefinition.plugins?.find(
     (m) => m.id === pluginEntityId,
   );
@@ -47,7 +47,7 @@ function setPluginConfig(
   pluginImplementationStore: PluginImplementationStore,
 ): void {
   const plugins = projectDefinition.plugins ?? [];
-  const pluginEntityId = pluginEntityType.fromUid(plugin.id);
+  const pluginEntityId = pluginEntityType.idFromKey(plugin.id);
 
   const pluginConfigService =
     pluginImplementationStore.getPluginSpec(pluginConfigSpec);

--- a/packages/project-builder-lib/src/migrations/migration-011-plugin-id.ts
+++ b/packages/project-builder-lib/src/migrations/migration-011-plugin-id.ts
@@ -12,6 +12,6 @@ export const migration011PluginId = createSchemaMigration<
   description: 'Convert plugin ids to use the plugin entity type',
   migrate: (config) =>
     transformJsonPath(config, 'plugins.*.id', (id: string) =>
-      pluginEntityType.fromUid(id),
+      pluginEntityType.idFromKey(id),
     ),
 });

--- a/packages/project-builder-lib/src/plugins/migrations/run-migrations.ts
+++ b/packages/project-builder-lib/src/plugins/migrations/run-migrations.ts
@@ -18,7 +18,7 @@ export function runPluginMigrations(
   return produce(projectDefinition, (draft) => {
     for (const pluginDefinition of draft.plugins ?? []) {
       const pluginMigrations = pluginConfigService.getMigrations(
-        pluginEntityType.toUid(pluginDefinition.id),
+        pluginEntityType.keyFromId(pluginDefinition.id),
       );
       const currentSchemaVersion = pluginDefinition.configSchemaVersion ?? -1;
       if (!pluginMigrations) continue;

--- a/packages/project-builder-lib/src/references/deserialize-schema.unit.test.ts
+++ b/packages/project-builder-lib/src/references/deserialize-schema.unit.test.ts
@@ -88,7 +88,7 @@ describe('deserializeSchemaWithReferences', () => {
       }),
     });
     const dataInput: z.input<typeof schema> = {
-      entity: [{ id: entityType.fromUid('test-id'), name: 'test-name' }],
+      entity: [{ id: entityType.idFromKey('test-id'), name: 'test-name' }],
       ref: '',
     };
 

--- a/packages/project-builder-lib/src/references/fix-ref-deletions.unit.test.ts
+++ b/packages/project-builder-lib/src/references/fix-ref-deletions.unit.test.ts
@@ -40,8 +40,8 @@ describe('fixRefDeletions', () => {
       ),
     });
     const data: z.TypeOf<typeof schema> = {
-      entity: [{ id: entityType.fromUid('test-id2'), name: 'test-name' }],
-      refs: [entityType.fromUid('test-id')],
+      entity: [{ id: entityType.idFromKey('test-id2'), name: 'test-name' }],
+      refs: [entityType.idFromKey('test-id')],
     };
 
     const refPayload = fixRefDeletions(schema, data);
@@ -49,7 +49,7 @@ describe('fixRefDeletions', () => {
     expect(refPayload).toMatchObject({
       type: 'success',
       value: {
-        entity: [{ id: entityType.fromUid('test-id2'), name: 'test-name' }],
+        entity: [{ id: entityType.idFromKey('test-id2'), name: 'test-name' }],
         refs: [],
       },
     });
@@ -71,12 +71,12 @@ describe('fixRefDeletions', () => {
       ),
     });
     const data: z.TypeOf<typeof schema> = {
-      entity: [{ id: entityType.fromUid('test-id2'), name: 'test-name' }],
+      entity: [{ id: entityType.idFromKey('test-id2'), name: 'test-name' }],
       refs: [
-        entityType.fromUid('test-id'),
-        entityType.fromUid('test-id2'),
-        entityType.fromUid('test-id'),
-        entityType.fromUid('test-id2'),
+        entityType.idFromKey('test-id'),
+        entityType.idFromKey('test-id2'),
+        entityType.idFromKey('test-id'),
+        entityType.idFromKey('test-id2'),
       ],
     };
 
@@ -85,8 +85,11 @@ describe('fixRefDeletions', () => {
     expect(refPayload).toMatchObject({
       type: 'success',
       value: {
-        entity: [{ id: entityType.fromUid('test-id2'), name: 'test-name' }],
-        refs: [entityType.fromUid('test-id2'), entityType.fromUid('test-id2')],
+        entity: [{ id: entityType.idFromKey('test-id2'), name: 'test-name' }],
+        refs: [
+          entityType.idFromKey('test-id2'),
+          entityType.idFromKey('test-id2'),
+        ],
       },
     });
   });
@@ -107,8 +110,8 @@ describe('fixRefDeletions', () => {
       ),
     });
     const data: z.TypeOf<typeof schema> = {
-      entity: [{ id: entityType.fromUid('test-id2'), name: 'test-name' }],
-      refs: [entityType.fromUid('test-id')],
+      entity: [{ id: entityType.idFromKey('test-id2'), name: 'test-name' }],
+      refs: [entityType.idFromKey('test-id')],
     };
 
     const refPayload = fixRefDeletions(schema, data);
@@ -116,7 +119,7 @@ describe('fixRefDeletions', () => {
     expect(refPayload).toMatchObject({
       type: 'success',
       value: {
-        entity: [{ id: entityType.fromUid('test-id2'), name: 'test-name' }],
+        entity: [{ id: entityType.idFromKey('test-id2'), name: 'test-name' }],
         refs: [null],
       },
     });
@@ -138,8 +141,8 @@ describe('fixRefDeletions', () => {
       ),
     });
     const data: z.TypeOf<typeof schema> = {
-      entity: [{ id: entityType.fromUid('test-id2'), name: 'test-name' }],
-      refs: [entityType.fromUid('test-id')],
+      entity: [{ id: entityType.idFromKey('test-id2'), name: 'test-name' }],
+      refs: [entityType.idFromKey('test-id')],
     };
 
     const refPayload = fixRefDeletions(schema, data);
@@ -148,6 +151,6 @@ describe('fixRefDeletions', () => {
     assert.ok(refPayload.type === 'failure');
 
     expect(refPayload.issues[0].ref.path.join('.')).toBe('refs.0');
-    expect(refPayload.issues[0].entityId).toBe(entityType.fromUid('test-id'));
+    expect(refPayload.issues[0].entityId).toBe(entityType.idFromKey('test-id'));
   });
 });

--- a/packages/project-builder-lib/src/references/ref-builder.unit.test.ts
+++ b/packages/project-builder-lib/src/references/ref-builder.unit.test.ts
@@ -38,14 +38,14 @@ describe('ref-builder', () => {
     });
     // Input data: entity has an explicit id and name; ref is set to the entity id.
     const input = {
-      entity: { id: entityType.fromUid('ent-1'), name: 'Entity One' },
-      ref: entityType.fromUid('ent-1'),
+      entity: { id: entityType.idFromKey('ent-1'), name: 'Entity One' },
+      ref: entityType.idFromKey('ent-1'),
     };
 
     // ZodRefWrapper returns a payload containing the parsed data as well as collected entities and references.
     const payload = ZodRefWrapper.create(schema).parse(input);
     // The reference should be resolved to the entity's id.
-    expect(payload.data.ref).toEqual(entityType.fromUid('ent-1'));
+    expect(payload.data.ref).toEqual(entityType.idFromKey('ent-1'));
     expect(payload.entitiesWithNameResolver).toHaveLength(1);
     expect(payload.references).toHaveLength(1);
   });
@@ -91,23 +91,23 @@ describe('ref-builder', () => {
     });
     const input = {
       model: {
-        id: modelType.fromUid('model-1'),
+        id: modelType.idFromKey('model-1'),
         name: 'Model One',
-        field: { id: fieldType.fromUid('field-1'), name: 'Field One' },
+        field: { id: fieldType.idFromKey('field-1'), name: 'Field One' },
       },
       foreignRelation: {
-        modelRef: modelType.fromUid('model-1'),
-        fieldRef: fieldType.fromUid('field-1'),
+        modelRef: modelType.idFromKey('model-1'),
+        fieldRef: fieldType.idFromKey('field-1'),
       },
     } satisfies z.infer<typeof schema>;
     const payload = ZodRefWrapper.create(schema).parse(input);
     // The reference field should resolve to the model's id.
     expect(payload.data.foreignRelation.modelRef).toEqual(
-      modelType.fromUid('model-1'),
+      modelType.idFromKey('model-1'),
     );
     // Verify that the model entity is collected.
     const modelEntity = payload.entitiesWithNameResolver.find(
-      (e) => e.id === modelType.fromUid('model-1'),
+      (e) => e.id === modelType.idFromKey('model-1'),
     );
     expect(modelEntity).toBeDefined();
   });
@@ -131,14 +131,14 @@ describe('ref-builder', () => {
       }),
     });
     const input = {
-      entity: { id: entityType.fromUid('e1'), name: 'E1' },
-      ref1: entityType.fromUid('e1'),
-      ref2: entityType.fromUid('e1'),
+      entity: { id: entityType.idFromKey('e1'), name: 'E1' },
+      ref1: entityType.idFromKey('e1'),
+      ref2: entityType.idFromKey('e1'),
     };
     const payload = ZodRefWrapper.create(schema).parse(input);
     // Both references should resolve to the entity name.
-    expect(payload.data.ref1).toEqual(entityType.fromUid('e1'));
-    expect(payload.data.ref2).toEqual(entityType.fromUid('e1'));
+    expect(payload.data.ref1).toEqual(entityType.idFromKey('e1'));
+    expect(payload.data.ref2).toEqual(entityType.idFromKey('e1'));
     // Verify that exactly one entity and two references are collected.
     expect(payload.entitiesWithNameResolver).toHaveLength(1);
     expect(payload.references).toHaveLength(2);
@@ -165,11 +165,11 @@ describe('ref-builder', () => {
 
     const input = {
       entity: {
-        id: entityType.fromUid('e1'),
+        id: entityType.idFromKey('e1'),
         firstName: 'John',
         lastName: 'Doe',
       },
-      ref: entityType.fromUid('e1'),
+      ref: entityType.idFromKey('e1'),
     };
 
     const payload = ZodRefWrapper.create(schema).parse(input);
@@ -207,21 +207,21 @@ describe('ref-builder', () => {
     });
 
     const input = {
-      company: { id: companyType.fromUid('c1'), name: 'Acme Corp' },
+      company: { id: companyType.idFromKey('c1'), name: 'Acme Corp' },
       person: {
-        id: personType.fromUid('p1'),
+        id: personType.idFromKey('p1'),
         name: 'Alice',
-        companyId: companyType.fromUid('c1'),
+        companyId: companyType.idFromKey('c1'),
       },
-      personRef: personType.fromUid('p1'),
+      personRef: personType.idFromKey('p1'),
     };
 
     const payload = ZodRefWrapper.create(schema).parse(input);
     const person = payload.entitiesWithNameResolver.find(
-      (e) => e.id === personType.fromUid('p1'),
+      (e) => e.id === personType.idFromKey('p1'),
     );
     expect(person?.nameResolver.idsToResolve).toEqual({
-      company: companyType.fromUid('c1'),
+      company: companyType.idFromKey('c1'),
     });
     expect(person?.nameResolver.resolveName({ company: 'Acme Corp' })).toBe(
       'Alice at Acme Corp',

--- a/packages/project-builder-lib/src/references/serialize-schema.unit.test.ts
+++ b/packages/project-builder-lib/src/references/serialize-schema.unit.test.ts
@@ -34,14 +34,14 @@ describe('serializeSchema', () => {
       }),
     });
     const data: z.TypeOf<typeof schema> = {
-      entity: [{ id: entityType.fromUid('test-id'), name: 'test-name' }],
-      ref: entityType.fromUid('test-id'),
+      entity: [{ id: entityType.idFromKey('test-id'), name: 'test-name' }],
+      ref: entityType.idFromKey('test-id'),
     };
 
     const refPayload = serializeSchema(schema, data);
 
     expect(refPayload).toMatchObject({
-      entity: [{ id: entityType.fromUid('test-id'), name: 'test-name' }],
+      entity: [{ id: entityType.idFromKey('test-id'), name: 'test-name' }],
       ref: 'test-name',
     });
   });
@@ -72,22 +72,22 @@ describe('serializeSchema', () => {
 
     const data: z.TypeOf<typeof schema> = {
       entity: [
-        { id: entityType.fromUid('test-id1'), name: 'test-name' },
-        { id: entityType.fromUid('test-id2'), name: 'test-name2' },
-        { id: entityType.fromUid('test-id3'), name: 'test-name3' },
+        { id: entityType.idFromKey('test-id1'), name: 'test-name' },
+        { id: entityType.idFromKey('test-id2'), name: 'test-name2' },
+        { id: entityType.idFromKey('test-id3'), name: 'test-name3' },
       ],
       nestedRef: {
-        ref: entityType.fromUid('test-id2'),
+        ref: entityType.idFromKey('test-id2'),
       },
-      ref: entityType.fromUid('test-id3'),
+      ref: entityType.idFromKey('test-id3'),
     };
     const refPayload = serializeSchema(schema, data);
 
     expect(refPayload).toMatchObject({
       entity: [
-        { id: entityType.fromUid('test-id1'), name: 'test-name' },
-        { id: entityType.fromUid('test-id2'), name: 'test-name2' },
-        { id: entityType.fromUid('test-id3'), name: 'test-name3' },
+        { id: entityType.idFromKey('test-id1'), name: 'test-name' },
+        { id: entityType.idFromKey('test-id2'), name: 'test-name2' },
+        { id: entityType.idFromKey('test-id3'), name: 'test-name3' },
       ],
       nestedRef: {
         ref: 'test-name2',
@@ -141,25 +141,25 @@ describe('serializeSchema', () => {
     const data: z.TypeOf<typeof schema> = {
       models: [
         {
-          id: modelType.fromUid('model-todo'),
+          id: modelType.idFromKey('model-todo'),
           name: 'todo',
           fields: [
-            { id: fieldType.fromUid('todo-title'), name: 'title' },
-            { id: fieldType.fromUid('todo-id'), name: 'id' },
+            { id: fieldType.idFromKey('todo-title'), name: 'title' },
+            { id: fieldType.idFromKey('todo-id'), name: 'id' },
           ],
           relations: [
             {
-              modelName: modelType.fromUid('model-todoList'),
-              fields: [fieldType.fromUid('todoList-id')],
+              modelName: modelType.idFromKey('model-todoList'),
+              fields: [fieldType.idFromKey('todoList-id')],
             },
           ],
         },
         {
-          id: modelType.fromUid('model-todoList'),
+          id: modelType.idFromKey('model-todoList'),
           name: 'todoList',
           fields: [
-            { id: fieldType.fromUid('todoList-title'), name: 'title' },
-            { id: fieldType.fromUid('todoList-id'), name: 'id' },
+            { id: fieldType.idFromKey('todoList-title'), name: 'title' },
+            { id: fieldType.idFromKey('todoList-id'), name: 'id' },
           ],
           relations: [],
         },
@@ -170,20 +170,20 @@ describe('serializeSchema', () => {
     expect(refPayload).toMatchObject({
       models: [
         {
-          id: modelType.fromUid('model-todo'),
+          id: modelType.idFromKey('model-todo'),
           name: 'todo',
           fields: [
-            { id: fieldType.fromUid('todo-title'), name: 'title' },
-            { id: fieldType.fromUid('todo-id'), name: 'id' },
+            { id: fieldType.idFromKey('todo-title'), name: 'title' },
+            { id: fieldType.idFromKey('todo-id'), name: 'id' },
           ],
           relations: [{ modelName: 'todoList', fields: ['id'] }],
         },
         {
-          id: modelType.fromUid('model-todoList'),
+          id: modelType.idFromKey('model-todoList'),
           name: 'todoList',
           fields: [
-            { id: fieldType.fromUid('todoList-title'), name: 'title' },
-            { id: fieldType.fromUid('todoList-id'), name: 'id' },
+            { id: fieldType.idFromKey('todoList-title'), name: 'title' },
+            { id: fieldType.idFromKey('todoList-id'), name: 'id' },
           ],
           relations: [],
         },

--- a/packages/project-builder-lib/src/references/types.ts
+++ b/packages/project-builder-lib/src/references/types.ts
@@ -1,4 +1,4 @@
-import { randomUid } from '@baseplate-dev/utils';
+import { randomKey } from '@baseplate-dev/utils';
 
 export type ReferencePath = (string | number)[];
 
@@ -31,25 +31,25 @@ export class DefinitionEntityType<THasParent extends boolean = boolean> {
    * @returns The new ID.
    */
   generateNewId(): string {
-    return `${this.prefix}:${randomUid()}`;
+    return `${this.prefix}:${randomKey()}`;
   }
 
   /**
-   * Converts a UID to an ID.
+   * Converts a key to an ID.
    *
-   * @param uid - The UID to convert.
+   * @param key - The key to convert.
    * @returns The ID.
    */
-  fromUid(uid: string): string;
-  fromUid(uid: string | undefined): string | undefined;
-  fromUid(uid: string | undefined): string | undefined {
-    if (!uid) {
+  idFromKey(key: string): string;
+  idFromKey(key: string | undefined): string | undefined;
+  idFromKey(key: string | undefined): string | undefined {
+    if (!key) {
       return undefined;
     }
-    return `${this.prefix}:${uid}`;
+    return `${this.prefix}:${key}`;
   }
 
-  toUid(id: string): string {
+  keyFromId(id: string): string {
     return id.split(':')[1];
   }
 

--- a/packages/project-builder-lib/src/schema/plugins/definition.ts
+++ b/packages/project-builder-lib/src/schema/plugins/definition.ts
@@ -23,7 +23,7 @@ export type BasePluginDefinition = z.infer<typeof basePluginDefinitionSchema>;
 export const pluginWithConfigSchema = zWithPlugins((plugins, data) => {
   const parsedBasePluginSchema = basePluginDefinitionSchema.parse(data);
 
-  const pluginId = pluginEntityType.toUid(parsedBasePluginSchema.id);
+  const pluginId = pluginEntityType.keyFromId(parsedBasePluginSchema.id);
 
   const configSchema = plugins
     .getPluginSpec(pluginConfigSpec)

--- a/packages/project-builder-server/src/server/index.ts
+++ b/packages/project-builder-server/src/server/index.ts
@@ -12,6 +12,17 @@ export interface StartWebServerOptions extends WebServerOptions {
 
 export { BuilderServiceManager } from './builder-service-manager.js';
 
+async function startListen(
+  server: FastifyInstance,
+  port: number,
+): Promise<void> {
+  await server.listen({
+    port,
+    listenTextResolver: (address) =>
+      `Baseplate is listening on ${address.replace('127.0.0.1', 'localhost')}`,
+  });
+}
+
 export async function startWebServer(
   options: StartWebServerOptions,
 ): Promise<FastifyInstance> {
@@ -19,7 +30,7 @@ export async function startWebServer(
   const server = await buildServer(options);
 
   try {
-    await server.listen({ port });
+    await startListen(server, port);
   } catch (error) {
     if (
       error instanceof Error &&
@@ -32,7 +43,7 @@ export async function startWebServer(
       await new Promise((resolve) => {
         setTimeout(resolve, 500);
       });
-      await server.listen({ port });
+      await startListen(server, port);
     } else {
       throw error;
     }

--- a/packages/project-builder-server/src/sync/generate-for-directory.ts
+++ b/packages/project-builder-server/src/sync/generate-for-directory.ts
@@ -17,7 +17,7 @@ import {
   writeGeneratorOutput,
   writeTemplateMetadata,
 } from '@baseplate-dev/sync';
-import { randomUid } from '@baseplate-dev/utils';
+import { randomKey } from '@baseplate-dev/utils';
 import { dirExists } from '@baseplate-dev/utils/node';
 import chalk from 'chalk';
 import { mkdir, rename, rm } from 'node:fs/promises';
@@ -245,7 +245,7 @@ export async function generateForDirectory({
     return {
       filesWithConflicts,
       failedCommands: failedCommands.map((c) => ({
-        id: randomUid(),
+        id: randomKey(),
         command: c.command,
         workingDir: c.workingDir,
         output: c.output,

--- a/packages/project-builder-web/package.json
+++ b/packages/project-builder-web/package.json
@@ -22,6 +22,7 @@
     "build": "tsc -b && vite build",
     "clean": "rm -rf ./dist",
     "dev": "vite",
+    "dev:serve": "vite --clearScreen false",
     "lint": "eslint .",
     "prettier:check": "prettier --check .",
     "prettier:write": "prettier -w .",

--- a/packages/project-builder-web/src/pages/apps/apps-layout.page.tsx
+++ b/packages/project-builder-web/src/pages/apps/apps-layout.page.tsx
@@ -35,7 +35,7 @@ function AppsLayout(): React.JSX.Element {
           <NavigationMenuList>
             {sortedApps.map((app) => (
               <NavigationMenuItemWithLink key={app.id} asChild>
-                <NavLink to={`/apps/edit/${appEntityType.toUid(app.id)}`}>
+                <NavLink to={`/apps/edit/${appEntityType.keyFromId(app.id)}`}>
                   {app.name}
                 </NavLink>
               </NavigationMenuItemWithLink>

--- a/packages/project-builder-web/src/pages/apps/edit.page.tsx
+++ b/packages/project-builder-web/src/pages/apps/edit.page.tsx
@@ -23,16 +23,16 @@ import BackendAppForm from './edit/backend-app-form.js';
 import WebAppForm from './edit/web-app-form.js';
 
 function EditAppPage(): React.JSX.Element {
-  const { uid } = useParams<'uid'>();
+  const { key } = useParams<'key'>();
   const { saveDefinitionWithFeedbackSync, definition, isSavingDefinition } =
     useProjectDefinition();
 
-  const id = uid ? appEntityType.fromUid(uid) : undefined;
+  const id = key ? appEntityType.idFromKey(key) : undefined;
   const app = id && definition.apps.find((a) => a.id === id);
 
   const navigate = useNavigate();
 
-  if (!uid || !app) {
+  if (!key || !app) {
     return <NotFoundCard />;
   }
 

--- a/packages/project-builder-web/src/pages/apps/edit/admin/admin-edit-section-form.tsx
+++ b/packages/project-builder-web/src/pages/apps/edit/admin/admin-edit-section-form.tsx
@@ -49,7 +49,7 @@ function AdminEditSectionForm({
   const navigate = useNavigate();
 
   const sectionId = sectionUid
-    ? adminSectionEntityType.fromUid(sectionUid)
+    ? adminSectionEntityType.idFromKey(sectionUid)
     : undefined;
 
   const existingSection = sectionId
@@ -92,7 +92,7 @@ function AdminEditSectionForm({
       {
         onSuccess: () => {
           if (!sectionId) {
-            navigate(`edit/${adminSectionEntityType.toUid(id)}`);
+            navigate(`edit/${adminSectionEntityType.keyFromId(id)}`);
           }
         },
       },

--- a/packages/project-builder-web/src/pages/apps/edit/admin/admin-sections-form.tsx
+++ b/packages/project-builder-web/src/pages/apps/edit/admin/admin-sections-form.tsx
@@ -19,7 +19,7 @@ import AdminEditSectionForm from './admin-edit-section-form.js';
 
 registerEntityTypeUrl(
   adminSectionEntityType,
-  `/apps/edit/{parentUid}/sections/edit/{uid}`,
+  `/apps/edit/{parentKey}/sections/edit/{key}`,
 );
 
 interface Props {
@@ -50,7 +50,9 @@ function AdminSectionsForm({ className, appConfig }: Props): React.JSX.Element {
             {sortedSections.map((section) => (
               <li key={section.id}>
                 <NavigationMenuItemWithLink asChild>
-                  <Link to={`edit/${adminSectionEntityType.toUid(section.id)}`}>
+                  <Link
+                    to={`edit/${adminSectionEntityType.keyFromId(section.id)}`}
+                  >
                     {section.name}
                   </Link>
                 </NavigationMenuItemWithLink>

--- a/packages/project-builder-web/src/pages/apps/index.tsx
+++ b/packages/project-builder-web/src/pages/apps/index.tsx
@@ -2,7 +2,7 @@ import type { RouteObject } from 'react-router-dom';
 
 import { appEntityType } from '@baseplate-dev/project-builder-lib';
 
-import { createCrumbFromUid } from '#src/types/routes.js';
+import { createCrumbFromKey } from '#src/types/routes.js';
 
 import NotFoundPage from '../not-found.page.js';
 import AppsLayout from './apps-layout.page.js';
@@ -17,10 +17,10 @@ export const AppsRoutes: RouteObject[] = [
       { index: true, element: <AppsListPage /> },
       { path: 'new', element: <NewAppPage />, handle: { crumb: 'New App' } },
       {
-        path: 'edit/:uid/*',
+        path: 'edit/:key/*',
         element: <EditAppPage />,
         handle: {
-          crumb: createCrumbFromUid(appEntityType, 'Edit App'),
+          crumb: createCrumbFromKey(appEntityType, 'Edit App'),
         },
       },
       { path: '*', element: <NotFoundPage /> },

--- a/packages/project-builder-web/src/pages/apps/list.page.tsx
+++ b/packages/project-builder-web/src/pages/apps/list.page.tsx
@@ -50,7 +50,7 @@ export function AppsListPage(): React.JSX.Element {
               </p>
             </div>
             <Link
-              to={`/apps/edit/${appEntityType.toUid(app.id)}`}
+              to={`/apps/edit/${appEntityType.keyFromId(app.id)}`}
               className="inline-block"
             >
               <Button variant="secondary">Edit</Button>

--- a/packages/project-builder-web/src/pages/apps/new.page.tsx
+++ b/packages/project-builder-web/src/pages/apps/new.page.tsx
@@ -47,7 +47,7 @@ function NewAppPage(): React.JSX.Element {
       },
       {
         onSuccess: () => {
-          navigate(`../edit/${appEntityType.toUid(data.id)}`);
+          navigate(`../edit/${appEntityType.keyFromId(data.id)}`);
           toast.success(`Sucessfully created ${data.name}!`);
         },
       },

--- a/packages/project-builder-web/src/pages/data/enums/edit/enum-edit-layout.tsx
+++ b/packages/project-builder-web/src/pages/data/enums/edit/enum-edit-layout.tsx
@@ -12,10 +12,10 @@ import { NotFoundCard } from '#src/components/index.js';
 import { EnumHeaderBar } from './components/enum-header-bar.js';
 
 export function EnumEditLayout(): React.JSX.Element {
-  const { uid } = useParams<'uid'>();
+  const { key } = useParams<'key'>();
   const { definition } = useProjectDefinition();
 
-  const id = modelEnumEntityType.fromUid(uid);
+  const id = modelEnumEntityType.idFromKey(key);
 
   const enumDefinition = EnumUtils.byId(definition, id ?? '');
 

--- a/packages/project-builder-web/src/pages/data/enums/edit/index.tsx
+++ b/packages/project-builder-web/src/pages/data/enums/edit/index.tsx
@@ -3,19 +3,19 @@ import type { RouteObject } from 'react-router-dom';
 import { modelEnumEntityType } from '@baseplate-dev/project-builder-lib';
 
 import { NotFoundRoute } from '#src/pages/not-found.page.js';
-import { createCrumbFromUid } from '#src/types/routes.js';
+import { createCrumbFromKey } from '#src/types/routes.js';
 
 import EnumEditPage from './edit.page.js';
 import { EnumEditLayout } from './enum-edit-layout.js';
 
 export const EnumEditRoutes: RouteObject = {
-  path: 'edit/:uid/*',
+  path: 'edit/:key/*',
   element: <EnumEditLayout />,
   handle: {
-    crumb: createCrumbFromUid(
+    crumb: createCrumbFromKey(
       modelEnumEntityType,
       'Edit Enum',
-      '/data/enums/edit/:uid',
+      '/data/enums/edit/:key',
     ),
   },
   children: [{ index: true, element: <EnumEditPage /> }, NotFoundRoute],

--- a/packages/project-builder-web/src/pages/data/enums/hooks/use-enum-form.tsx
+++ b/packages/project-builder-web/src/pages/data/enums/hooks/use-enum-form.tsx
@@ -52,12 +52,12 @@ export function useEnumForm({
   defaultValues: EnumConfigInput;
   isSavingDefinition: boolean;
 } {
-  const { uid } = useParams<'uid'>();
+  const { key } = useParams<'key'>();
   const { definition, saveDefinitionWithFeedback, isSavingDefinition } =
     useProjectDefinition();
   const navigate = useNavigate();
 
-  const urlEnumId = isCreate ? undefined : modelEnumEntityType.fromUid(uid);
+  const urlEnumId = isCreate ? undefined : modelEnumEntityType.idFromKey(key);
   const enumDefinition = urlEnumId
     ? EnumUtils.byId(definition, urlEnumId)
     : undefined;
@@ -66,7 +66,7 @@ export function useEnumForm({
     throw new NotFoundError('Enum not found');
   }
 
-  // memoize it to keep the same UID when resetting
+  // memoize it to keep the same key when resetting
   const newEnumDefinition = useMemo(() => createNewEnum(), []);
 
   const enumSchemaWithPlugins = usePluginEnhancedSchema(schema ?? enumSchema);

--- a/packages/project-builder-web/src/pages/data/models/_hooks/use-model-form.ts
+++ b/packages/project-builder-web/src/pages/data/models/_hooks/use-model-form.ts
@@ -73,11 +73,11 @@ export function useModelForm({
   originalModel?: ModelConfig;
   defaultValues: ModelConfigInput;
 } {
-  const { uid } = useParams<'uid'>();
+  const { key } = useParams<'key'>();
   const { definition, saveDefinitionWithFeedback } = useProjectDefinition();
   const navigate = useNavigate();
 
-  const urlModelId = isCreate ? undefined : modelEntityType.fromUid(uid);
+  const urlModelId = isCreate ? undefined : modelEntityType.idFromKey(key);
   const model = urlModelId
     ? ModelUtils.byIdOrThrow(definition, urlModelId)
     : undefined;
@@ -88,7 +88,7 @@ export function useModelForm({
     );
   }
 
-  // memoize it to keep the same UID when resetting
+  // memoize it to keep the same key when resetting
   const newModel = useMemo(() => createNewModel(), []);
 
   const modelSchemaWithPlugins = usePluginEnhancedSchema(schema ?? modelSchema);

--- a/packages/project-builder-web/src/pages/data/models/_utils/url.ts
+++ b/packages/project-builder-web/src/pages/data/models/_utils/url.ts
@@ -4,15 +4,15 @@ import {
 } from '@baseplate-dev/project-builder-lib';
 
 export function createModelEditLink(modelId: string): string {
-  const uid = modelEntityType.isId(modelId)
-    ? modelEntityType.toUid(modelId)
+  const key = modelEntityType.isId(modelId)
+    ? modelEntityType.keyFromId(modelId)
     : modelId;
-  return `/data/models/edit/${uid}`;
+  return `/data/models/edit/${key}`;
 }
 
 export function createEnumEditLink(enumId: string): string {
-  const uid = modelEnumEntityType.isId(enumId)
-    ? modelEnumEntityType.toUid(enumId)
+  const key = modelEnumEntityType.isId(enumId)
+    ? modelEnumEntityType.keyFromId(enumId)
     : enumId;
-  return `/data/enums/edit/${uid}`;
+  return `/data/enums/edit/${key}`;
 }

--- a/packages/project-builder-web/src/pages/data/models/edit/[id]/_layout.tsx
+++ b/packages/project-builder-web/src/pages/data/models/edit/[id]/_layout.tsx
@@ -16,10 +16,10 @@ import { NotFoundCard } from '#src/components/index.js';
 import { ModelHeaderBar } from './_components/model-header-bar.js';
 
 export function ModelEditLayout(): React.JSX.Element {
-  const { uid } = useParams<'uid'>();
+  const { key } = useParams<'key'>();
   const { definition } = useProjectDefinition();
 
-  const id = modelEntityType.fromUid(uid);
+  const id = modelEntityType.idFromKey(key);
 
   const model = ModelUtils.byId(definition, id ?? '');
 

--- a/packages/project-builder-web/src/pages/data/models/edit/[id]/_routes.tsx
+++ b/packages/project-builder-web/src/pages/data/models/edit/[id]/_routes.tsx
@@ -4,7 +4,7 @@ import { modelEntityType } from '@baseplate-dev/project-builder-lib';
 import { Navigate } from 'react-router-dom';
 
 import { NotFoundRoute } from '#src/pages/not-found.page.js';
-import { createCrumbFromUid, createRouteCrumb } from '#src/types/routes.js';
+import { createCrumbFromKey, createRouteCrumb } from '#src/types/routes.js';
 
 import { ModelEditLayout } from './_layout.js';
 import ModelEditGraphQLPage from './graphql.page.js';
@@ -19,13 +19,13 @@ export const ModelEditRoutes: RouteObject = {
       element: <Navigate to="../" replace />,
     },
     {
-      path: ':uid',
+      path: ':key',
       element: <ModelEditLayout />,
       handle: {
-        crumb: createCrumbFromUid(
+        crumb: createCrumbFromKey(
           modelEntityType,
           'Edit Model',
-          '/data/models/edit/:uid',
+          '/data/models/edit/:key',
         ),
       },
       children: [

--- a/packages/project-builder-web/src/pages/data/models/edit/[id]/index.page.tsx
+++ b/packages/project-builder-web/src/pages/data/models/edit/[id]/index.page.tsx
@@ -18,14 +18,14 @@ import { ModelFieldsForm } from './_components/fields/model-fields-form.js';
 import { ModelRelationsSection } from './_components/model-relations-section.js';
 import { ModelUniqueConstraintsSection } from './_components/model-unique-constraints-section.js';
 
-registerEntityTypeUrl(modelEntityType, `/data/models/edit/{uid}`);
+registerEntityTypeUrl(modelEntityType, `/data/models/edit/{key}`);
 registerEntityTypeUrl(
   modelScalarFieldEntityType,
-  `/data/models/edit/{parentUid}`,
+  `/data/models/edit/{parentKey}`,
 );
 registerEntityTypeUrl(
   modelLocalRelationEntityType,
-  `/data/models/edit/{parentUid}`,
+  `/data/models/edit/{parentKey}`,
 );
 
 const formSchema = modelBaseSchema.omit({ name: true, featureRef: true });

--- a/packages/project-builder-web/src/pages/data/models/edit/[id]/service.page.tsx
+++ b/packages/project-builder-web/src/pages/data/models/edit/[id]/service.page.tsx
@@ -25,7 +25,7 @@ import { ServiceTransformersSection } from './_components/service/service-transf
 
 registerEntityTypeUrl(
   modelTransformerEntityType,
-  `/data/models/edit/{parentUid}`,
+  `/data/models/edit/{parentKey}`,
 );
 
 const formSchema = modelBaseSchema.omit({ name: true, featureRef: true });

--- a/packages/project-builder-web/src/pages/plugins/index.tsx
+++ b/packages/project-builder-web/src/pages/plugins/index.tsx
@@ -2,7 +2,7 @@ import type { RouteObject } from 'react-router-dom';
 
 import { pluginEntityType } from '@baseplate-dev/project-builder-lib';
 
-import { createCrumbFromUid } from '#src/types/routes.js';
+import { createCrumbFromKey } from '#src/types/routes.js';
 
 import NotFoundPage from '../not-found.page.js';
 import { PluginsHomePage } from './home.page.js';
@@ -20,7 +20,9 @@ export const PluginRoutes: RouteObject[] = [
       {
         path: 'edit/:id',
         element: <PluginConfigPage />,
-        handle: { crumb: createCrumbFromUid(pluginEntityType, 'Edit Plugin') },
+        handle: {
+          crumb: createCrumbFromKey(pluginEntityType, 'Edit Plugin'),
+        },
       },
       {
         path: '*',

--- a/packages/project-builder-web/src/pages/plugins/plugin-card.tsx
+++ b/packages/project-builder-web/src/pages/plugins/plugin-card.tsx
@@ -65,7 +65,7 @@ export function PluginCard({
               p.packageName !== plugin.packageName || p.name !== plugin.name,
           ),
           {
-            id: pluginEntityType.fromUid(plugin.id),
+            id: pluginEntityType.idFromKey(plugin.id),
             packageName: plugin.packageName,
             name: plugin.name,
             version: plugin.version,
@@ -83,7 +83,7 @@ export function PluginCard({
     saveDefinitionWithFeedbackSync(
       (draft) => {
         draft.plugins = (draft.plugins ?? []).filter(
-          (p) => p.id !== pluginEntityType.fromUid(plugin.id),
+          (p) => p.id !== pluginEntityType.idFromKey(plugin.id),
         );
       },
       {

--- a/packages/project-builder-web/src/pages/plugins/plugin-config.page.tsx
+++ b/packages/project-builder-web/src/pages/plugins/plugin-config.page.tsx
@@ -81,7 +81,7 @@ export function PluginConfigPage(): React.JSX.Element {
     saveDefinitionWithFeedbackSync(
       (draft) => {
         draft.plugins = (draft.plugins ?? []).filter(
-          (p) => p.id !== pluginEntityType.fromUid(metadata.id),
+          (p) => p.id !== pluginEntityType.idFromKey(metadata.id),
         );
       },
       {

--- a/packages/project-builder-web/src/pages/plugins/plugins-layout.tsx
+++ b/packages/project-builder-web/src/pages/plugins/plugins-layout.tsx
@@ -26,7 +26,7 @@ function PluginsLayout(): React.JSX.Element {
   const enabledPlugins = (definition.plugins ?? [])
     .map((plugin) => {
       const pluginWithMetadata = availablePlugins.find(
-        (p) => p.metadata.id === pluginEntityType.toUid(plugin.id),
+        (p) => p.metadata.id === pluginEntityType.keyFromId(plugin.id),
       );
       return pluginWithMetadata?.metadata;
     })

--- a/packages/project-builder-web/src/services/entity-type.ts
+++ b/packages/project-builder-web/src/services/entity-type.ts
@@ -22,15 +22,18 @@ export function getEntityTypeUrl(
 
   return typeUrl
     .replace('{id}', entity.id)
-    .replace('{uid}', entity.type.toUid(entity.id))
+    .replace('{key}', entity.type.keyFromId(entity.id))
     .replace('{parentId}', entityParent?.id ?? '')
-    .replace('{parentUid}', entityParent?.type.toUid(entityParent.id) ?? '');
+    .replace(
+      '{parentKey}',
+      entityParent?.type.keyFromId(entityParent.id) ?? '',
+    );
 }
 
 /**
  * Register a URL for an entity type.
  *
- * Use {id} as a placeholder for the entity ID and {uid} for the random part of the ID.
+ * Use {id} as a placeholder for the entity ID and {key} for the random part of the ID.
  */
 export function registerEntityTypeUrl(
   entityType: DefinitionEntityType,

--- a/packages/project-builder-web/src/types/routes.ts
+++ b/packages/project-builder-web/src/types/routes.ts
@@ -18,16 +18,16 @@ export function createRouteCrumb(
   return crumb;
 }
 
-export function createCrumbFromUid(
+export function createCrumbFromKey(
   entityType: DefinitionEntityType,
   defaultName: string,
   url?: string,
 ): RouteCrumbOrFunction {
   return createRouteCrumb((params, definition) => ({
     label:
-      (params.uid &&
-        definition.safeNameFromId(entityType.fromUid(params.uid))) ??
+      (params.key &&
+        definition.safeNameFromId(entityType.idFromKey(params.key))) ??
       defaultName,
-    url: url?.replace(':uid', params.uid ?? ''),
+    url: url?.replace(':key', params.key ?? ''),
   }));
 }

--- a/packages/utils/src/string/index.ts
+++ b/packages/utils/src/string/index.ts
@@ -1,2 +1,2 @@
 export * from './quot.js';
-export * from './random-uid.js';
+export * from './random-key.js';

--- a/packages/utils/src/string/random-key.ts
+++ b/packages/utils/src/string/random-key.ts
@@ -10,9 +10,9 @@ const UPPERCASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const customNanoid = customAlphabet(`${NUMBERS}${LOWERCASE}${UPPERCASE}_`, 12);
 
 /**
- * Generate a random ID string made up of numbers, lowercase, and uppercase letters
- * @returns A random ID string
+ * Generate a random key string made up of numbers, lowercase, and uppercase letters
+ * @returns A random key string
  */
-export function randomUid(length = 12): string {
+export function randomKey(length = 12): string {
   return customNanoid(length);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated all references of "UID" to "Key" across the application for improved clarity in identifiers, including URL parameters, navigation, and entity management.
  - Renamed related helper functions and parameters to use "Key" instead of "UID" throughout the user interface and routing.
- **Chores**
  - Enhanced development scripts to support running multiple packages in parallel.
  - Added a new development server script for the web interface.
- **Bug Fixes**
  - Standardized identifier handling in forms, navigation, and plugin management to ensure consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->