### PR TITLE
refactor: Use .optional() for dependency

### DIFF
--- a/packages/fastify-generators/src/generators/core/app-module/app-module.generator.ts
+++ b/packages/fastify-generators/src/generators/core/app-module/app-module.generator.ts
@@ -79,9 +79,7 @@ export const appModuleGenerator = createGenerator({
         typescriptFile: typescriptFileProvider,
         appModuleConfigValues: appModuleConfigValuesProvider,
         appModuleSetupImports: appModuleSetupImportsProvider,
-        appModule: isRoot
-          ? undefined
-          : appModuleProvider.dependency().parentScopeOnly(),
+        appModule: appModuleProvider.dependency().optional().parentScopeOnly(),
       },
       exports: {
         appModule: appModuleProvider.export(


### PR DESCRIPTION
- Seems to have fixed itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dependency injection behavior for app modules to consistently treat the app module as an optional dependency, regardless of module hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->