### PR TITLE
feat: Change generated CRUD service file naming from model-service.ts to model.crud.ts pattern

### DIFF
--- a/.changeset/crud-service-naming.md
+++ b/.changeset/crud-service-naming.md
@@ -1,0 +1,12 @@
+---
+'@baseplate-dev/project-builder-server': patch
+---
+
+Change generated CRUD service file naming from model-service.ts to model.crud.ts pattern
+
+This change updates the service file generation to use explicit `.crud.ts` naming instead of the previous `-service.ts` pattern. This provides better separation between generated CRUD operations and future hand-written business logic files, supporting the planned architectural split between generated and manual code.
+
+Example changes:
+
+- `user-service.ts` → `user.crud.ts`
+- `todo-item-service.ts` → `todo-item.crud.ts`

--- a/packages/project-builder-server/src/compiler/backend/services.ts
+++ b/packages/project-builder-server/src/compiler/backend/services.ts
@@ -21,6 +21,7 @@ import {
   undefinedIfEmpty,
 } from '@baseplate-dev/project-builder-lib';
 import { notEmpty } from '@baseplate-dev/utils';
+import { kebabCase } from 'change-case';
 
 import type { BackendAppEntryBuilder } from '../app-entry-builder.js';
 
@@ -99,6 +100,7 @@ function buildServiceForModel(
   return serviceFileGenerator({
     name: `${model.name}Service`,
     id: `prisma-crud-service:${model.name}`,
+    fileName: `${kebabCase(model.name)}.crud`,
     children: {
       $crud: prismaCrudServiceGenerator({
         modelName: model.name,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the naming convention for generated CRUD service files to use the `.crud.ts` suffix for improved clarity and separation from manually written files. This affects only file names and does not impact functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->