### PR TITLE
feat: Auto-fix linting and prettier format when running Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,17 @@
 {
   "enabledMcpjsonServers": ["baseplate-dev-server"],
-  "enableAllProjectMcpServers": false
+  "enableAllProjectMcpServers": false,
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | { read file_path; if [ -n \"$file_path\" ] && [ \"$file_path\" != \"null\" ]; then scripts/format-and-lint.ts \"$file_path\"; fi; }"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.devcontainer/.zshrc
+++ b/.devcontainer/.zshrc
@@ -16,7 +16,7 @@ if [ -f ~/.zplug/init.zsh ]; then
     zplug load
 fi
 
-bindkey '^S' autosuggest-accept
+bindkey '^E' autosuggest-accept
 
 # History settings
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -92,10 +92,6 @@ COPY --chown=$USERNAME:$USERNAME mise.toml .config/mise/config.toml
 
 # Install all tools defined in the config file using mise
 RUN mise install
-
-# Configure pnpm to use a specific store directory within the user's home
-ENV npm_config_store_dir="$HOME/.local/share/pnpm/store"
-
 # Set the default shell to zsh rather than sh
 ENV SHELL=/bin/zsh
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,7 @@
   "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
-    "CLAUDE_CONFIG_DIR": "/home/vscode/.claude",
-    "npm_config_package_import_method": "copy"
+    "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
   },
 
   "customizations": {
@@ -46,8 +45,6 @@
   "containerUser": "vscode",
 
   "mounts": [
-    "source=${localWorkspaceFolderBasename}-pnpm,target=/home/vscode/.local/share/pnpm,type=volume",
-    "source=${localWorkspaceFolderBasename}-node_modules,target=${localWorkspaceFolder}/node_modules,type=volume",
     "source=${localWorkspaceFolderBasename}-bashhistory,target=/commandhistory,type=volume",
     "source=${localWorkspaceFolderBasename}-claude,target=/home/vscode/.claude,type=volume"
   ],

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -72,6 +72,7 @@ for domain in \
     "statsig.com" \
     "marketplace.visualstudio.com" \
     "vscode.blob.core.windows.net" \
+    "binaries.prisma.sh" \
     "update.code.visualstudio.com"; do
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,8 +3,6 @@
 set -e
 
 # Fix permissions on pnpm store and remove sudo permissions
-sudo chown vscode:vscode node_modules
-sudo chown vscode:vscode /home/vscode/.local/share/pnpm
 sudo chown vscode:vscode /home/vscode/.claude
 sudo init-firewall.sh
 sudo rm /etc/sudoers.d/vscode

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ playground
 
 # Baseplate settings
 /.baseplate
+
+.pnpm-store

--- a/examples/blog-with-auth/pnpm-lock.yaml
+++ b/examples/blog-with-auth/pnpm-lock.yaml
@@ -4843,16 +4843,16 @@ packages:
         integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
       }
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.12:
     resolution:
       {
-        integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==,
+        integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
       }
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.0.2:
     resolution:
       {
-        integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==,
+        integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
       }
 
   braces@3.0.3:
@@ -13399,12 +13399,12 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@1.1.11:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.1:
+  brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -15097,15 +15097,15 @@ snapshots:
 
   minimatch@10.0.1:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 1.1.12
 
   minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
 

--- a/examples/todo-with-auth0/pnpm-lock.yaml
+++ b/examples/todo-with-auth0/pnpm-lock.yaml
@@ -4979,6 +4979,12 @@ packages:
         integrity: sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==,
       }
 
+  '@types/node@22.18.1':
+    resolution:
+      {
+        integrity: sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==,
+      }
+
   '@types/pg-pool@2.0.6':
     resolution:
       {
@@ -15300,7 +15306,7 @@ snapshots:
 
   '@types/ioredis-mock@8.2.5':
     dependencies:
-      '@types/node': 22.18.0
+      '@types/node': 22.18.1
       ioredis: 5.3.2
     transitivePeerDependencies:
       - supports-color
@@ -15318,6 +15324,10 @@ snapshots:
       '@types/node': 22.18.0
 
   '@types/node@22.18.0':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@22.18.1':
     dependencies:
       undici-types: 6.21.0
 

--- a/examples/todo-with-auth0/pnpm-workspace.yaml
+++ b/examples/todo-with-auth0/pnpm-workspace.yaml
@@ -1,5 +1,11 @@
 packages:
   - packages/*
+
+ignoredBuiltDependencies:
+  - '@tailwindcss/oxide'
+  - msgpackr-extract
+  - unrs-resolver
+
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - '@prisma/client'

--- a/scripts/format-and-lint.ts
+++ b/scripts/format-and-lint.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/* eslint-disable import-x/no-extraneous-dependencies */
+
+/**
+ * A resilient, monorepo-aware code formatting hook script in TypeScript.
+ *
+ * This script is designed for hooks that require prettifying and linting a particular file e.g. for Claude code.
+ * It finds the nearest `package.json` to determine the project root for a given file.
+ *
+ * For Prettier: It uses the Prettier Node API to format files. It first checks
+ * if a file is supported by Prettier using `getFileInfo` to avoid unnecessary work.
+ *
+ * For ESLint: It shells out to run `eslint --fix` because its Node API is more complex.
+ *
+ * The script runs a tool only if it's found as a dependency in the relevant `package.json`.
+ * It's resilient and will report errors from formatters without crashing the hook.
+ *
+ * Required dependencies:
+ * - typescript
+ * - ts-node
+ * - prettier
+ * - eslint
+ * - @types/node
+ * - @types/prettier
+ */
+
+import type { Options } from 'prettier';
+
+import { exec } from 'node:child_process';
+import * as fs from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import {
+  format,
+  getFileInfo,
+  resolveConfig,
+  resolveConfigFile,
+} from 'prettier';
+
+const execPromise = promisify(exec);
+
+const VALID_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
+
+// A cache for Prettier configurations to avoid repeated lookups for multiple files.
+const prettierConfigCache = new Map<string, Options | null>();
+
+/**
+ * Finds the nearest package.json file by traversing up from a starting directory.
+ * @param startDir The directory to start searching from.
+ * @returns An object with the path and directory of the package.json, or null if not found.
+ */
+function findNearestPackageJson(
+  startDir: string,
+): { pkgPath: string; pkgDir: string } | null {
+  let currentDir = startDir;
+  while (true) {
+    const pkgPath = path.join(currentDir, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      return { pkgPath, pkgDir: currentDir };
+    }
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      // Reached the root of the file system
+      return null;
+    }
+    currentDir = parentDir;
+  }
+}
+
+/**
+ * Resolves and caches the Prettier configuration for a given file path.
+ * @param filePath The path of the file to resolve config for.
+ * @returns The resolved Prettier options, or null if no config is found.
+ */
+async function getPrettierConfig(filePath: string): Promise<Options | null> {
+  const configFile = await resolveConfigFile(filePath);
+  if (!configFile) {
+    return null; // No config file found
+  }
+
+  // Return from cache if available
+  if (prettierConfigCache.has(configFile)) {
+    return prettierConfigCache.get(configFile) ?? null;
+  }
+
+  const config = await resolveConfig(filePath, { config: configFile });
+  prettierConfigCache.set(configFile, config);
+  return config;
+}
+
+/**
+ * Formats a file using the Prettier Node API.
+ * @param filePath The absolute path to the file to format.
+ */
+async function runPrettier(filePath: string): Promise<void> {
+  console.info(`Checking Prettier for ${path.basename(filePath)}...`);
+  try {
+    const fileInfo = await getFileInfo(filePath);
+
+    // Skip if file is ignored by .prettierignore or has no known parser
+    if (fileInfo.ignored || !fileInfo.inferredParser) {
+      console.info(
+        `Prettier is skipping ${path.basename(filePath)} (ignored or unsupported).`,
+      );
+      return;
+    }
+
+    const config = await getPrettierConfig(filePath);
+    if (!config) {
+      console.info(
+        `No Prettier config found for ${path.basename(filePath)}. Skipping.`,
+      );
+      return;
+    }
+
+    const content = fs.readFileSync(filePath, 'utf8');
+    const formattedContent = await format(content, {
+      ...config,
+      filepath: filePath,
+    });
+
+    if (content === formattedContent) {
+      console.info(`✅ Prettier check passed (already formatted).`);
+    } else {
+      fs.writeFileSync(filePath, formattedContent);
+      console.info(`✅ Prettier formatted ${path.basename(filePath)}.`);
+    }
+  } catch (error) {
+    console.error(`❌ Prettier failed for ${filePath}.`);
+    if (error instanceof Error) {
+      console.error(error.message);
+    }
+  }
+}
+
+/**
+ * Runs ESLint as a shell command to autofix a file.
+ * @param filePath The full path to the file to process.
+ * @param cwd The current working directory to run the command in.
+ */
+async function runEslint(filePath: string, cwd: string): Promise<void> {
+  console.info(
+    `Running ESLint on ${path.basename(filePath)} (in ${path.basename(cwd)})...`,
+  );
+  try {
+    await execPromise(`npx eslint --fix "${filePath}"`, { cwd });
+    console.info(`✅ ESLint completed successfully.`);
+  } catch (error) {
+    console.error(`❌ ESLint failed for ${filePath}.`);
+    // ESLint outputs errors to stdout/stderr, which execPromise includes in the error message.
+    console.error(error instanceof Error ? error.message : String(error));
+  }
+}
+
+const filePath = process.argv[2];
+
+if (!filePath) {
+  console.error('Error: Please provide a file path as an argument.');
+  process.exit(1);
+}
+
+const absoluteFilePath = path.resolve(filePath);
+const extension = path.extname(absoluteFilePath);
+
+if (!VALID_EXTENSIONS.has(extension)) {
+  console.info(
+    `Skipping file (unsupported extension): ${path.basename(absoluteFilePath)}`,
+  );
+  process.exit(0);
+}
+
+const fileDir = path.dirname(absoluteFilePath);
+const packageInfo = findNearestPackageJson(fileDir);
+
+if (!packageInfo) {
+  console.info(
+    `No package.json found for ${absoluteFilePath}. Skipping formatters.`,
+  );
+  process.exit(0);
+}
+
+const { pkgPath, pkgDir } = packageInfo;
+console.info(
+  `Found package context for ${path.basename(absoluteFilePath)} at: ${pkgDir}`,
+);
+
+const pkgContent = fs.readFileSync(pkgPath, 'utf8');
+const pkg = JSON.parse(pkgContent) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+const dependencies = { ...pkg.dependencies, ...pkg.devDependencies };
+
+// Conditionally run formatters based on project dependencies
+if (dependencies.eslint) {
+  await runEslint(absoluteFilePath, pkgDir);
+}
+if (dependencies.prettier) {
+  await runPrettier(absoluteFilePath);
+}
+
+console.info(`\nFormatting hook finished for ${absoluteFilePath}.`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic post-edit formatting and linting for edited files.

- Chores
  - Devcontainer updates: use default pnpm store, remove pnpm/node_modules mounts, set CLAUDE_CONFIG_DIR, and simplify post-create permissions.
  - Expanded firewall allowlist to include an additional binaries domain.
  - Changed shell autosuggest accept keybinding to Ctrl+E.
  - Added .pnpm-store to .gitignore.
  - Optimized workspace setup by ignoring select prebuilt dependencies to reduce install overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->