### PR TITLE
fix: Add pgboss plugin to server initializers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,5 +16,6 @@
   },
   "permissions": {
     "additionalDirectories": ["~/baseplate-docs"]
-  }
+  },
+  "model": "opusplan"
 }

--- a/examples/blog-with-auth/.prettierignore
+++ b/examples/blog-with-auth/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/examples/blog-with-auth/packages/backend/baseplate/generated/src/plugins/pg-boss.plugin.ts
+++ b/examples/blog-with-auth/packages/backend/baseplate/generated/src/plugins/pg-boss.plugin.ts
@@ -10,7 +10,7 @@ import {
 /**
  * Fastify plugin for pg-boss queue system initialization.
  */
-const pgBossPlugin: FastifyPluginAsync = async (fastify) => {
+const pgBossPluginCallback: FastifyPluginAsync = async (fastify) => {
   // Initialize pg-boss in API mode (maintenance disabled)
   await initializePgBoss({ disableMaintenance: true });
 
@@ -20,6 +20,6 @@ const pgBossPlugin: FastifyPluginAsync = async (fastify) => {
   });
 };
 
-export default fastifyPlugin(pgBossPlugin, {
+export const pgBossPlugin = fastifyPlugin(pgBossPluginCallback, {
   name: 'pg-boss',
 });

--- a/examples/blog-with-auth/packages/backend/baseplate/generated/src/server.ts
+++ b/examples/blog-with-auth/packages/backend/baseplate/generated/src/server.ts
@@ -11,6 +11,7 @@ import { errorHandlerPlugin } from './plugins/error-handler.js';
 import { gracefulShutdownPlugin } from './plugins/graceful-shutdown.js';
 import { graphqlPlugin } from './plugins/graphql/index.js';
 import { healthCheckPlugin } from './plugins/health-check.js';
+import { pgBossPlugin } from './plugins/pg-boss.plugin.js';
 import { requestContextPlugin } from './plugins/request-context.js';
 import { registerSentryEventProcessor } from './services/sentry.js';
 
@@ -38,6 +39,7 @@ export async function buildServer(
   await fastify.register(gracefulShutdownPlugin);
   await fastify.register(graphqlPlugin);
   await fastify.register(healthCheckPlugin);
+  await fastify.register(pgBossPlugin);
   await fastify.register(requestContextPlugin);
   /* TPL_PLUGINS:END */
 

--- a/examples/blog-with-auth/packages/backend/baseplate/generated/src/services/pg-boss.service.ts
+++ b/examples/blog-with-auth/packages/backend/baseplate/generated/src/services/pg-boss.service.ts
@@ -301,9 +301,6 @@ export function createQueue<T>(
   name: string,
   definition: QueueDefinition<T>,
 ): PgBossQueue<T> {
-  // Just ensure pg-boss is initialized
-  getPgBoss();
-
   return new PgBossQueue(name, definition);
 }
 

--- a/examples/blog-with-auth/packages/backend/src/plugins/pg-boss.plugin.ts
+++ b/examples/blog-with-auth/packages/backend/src/plugins/pg-boss.plugin.ts
@@ -10,7 +10,7 @@ import {
 /**
  * Fastify plugin for pg-boss queue system initialization.
  */
-const pgBossPlugin: FastifyPluginAsync = async (fastify) => {
+const pgBossPluginCallback: FastifyPluginAsync = async (fastify) => {
   // Initialize pg-boss in API mode (maintenance disabled)
   await initializePgBoss({ disableMaintenance: true });
 
@@ -20,6 +20,6 @@ const pgBossPlugin: FastifyPluginAsync = async (fastify) => {
   });
 };
 
-export default fastifyPlugin(pgBossPlugin, {
+export const pgBossPlugin = fastifyPlugin(pgBossPluginCallback, {
   name: 'pg-boss',
 });

--- a/examples/blog-with-auth/packages/backend/src/server.ts
+++ b/examples/blog-with-auth/packages/backend/src/server.ts
@@ -11,6 +11,7 @@ import { errorHandlerPlugin } from './plugins/error-handler.js';
 import { gracefulShutdownPlugin } from './plugins/graceful-shutdown.js';
 import { graphqlPlugin } from './plugins/graphql/index.js';
 import { healthCheckPlugin } from './plugins/health-check.js';
+import { pgBossPlugin } from './plugins/pg-boss.plugin.js';
 import { requestContextPlugin } from './plugins/request-context.js';
 import { registerSentryEventProcessor } from './services/sentry.js';
 
@@ -38,6 +39,7 @@ export async function buildServer(
   await fastify.register(gracefulShutdownPlugin);
   await fastify.register(graphqlPlugin);
   await fastify.register(healthCheckPlugin);
+  await fastify.register(pgBossPlugin);
   await fastify.register(requestContextPlugin);
   /* TPL_PLUGINS:END */
 

--- a/examples/blog-with-auth/packages/backend/src/services/pg-boss.service.ts
+++ b/examples/blog-with-auth/packages/backend/src/services/pg-boss.service.ts
@@ -301,9 +301,6 @@ export function createQueue<T>(
   name: string,
   definition: QueueDefinition<T>,
 ): PgBossQueue<T> {
-  // Just ensure pg-boss is initialized
-  getPgBoss();
-
   return new PgBossQueue(name, definition);
 }
 

--- a/examples/todo-with-auth0/.prettierignore
+++ b/examples/todo-with-auth0/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/pg-boss.generator.ts
+++ b/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/pg-boss.generator.ts
@@ -1,7 +1,12 @@
-import { nodeProvider } from '@baseplate-dev/core-generators';
+import {
+  nodeProvider,
+  tsCodeFragment,
+  tsImportBuilder,
+} from '@baseplate-dev/core-generators';
 import {
   fastifyOutputProvider,
   fastifyProvider,
+  fastifyServerConfigProvider,
 } from '@baseplate-dev/fastify-generators';
 import { createGenerator, createGeneratorTask } from '@baseplate-dev/sync';
 import { z } from 'zod';
@@ -23,6 +28,20 @@ export const pgBossGenerator = createGenerator({
     paths: GENERATED_TEMPLATES.paths.task,
     renderers: GENERATED_TEMPLATES.renderers.task,
     imports: GENERATED_TEMPLATES.imports.task,
+    fastifyServerConfig: createGeneratorTask({
+      dependencies: {
+        fastifyServerConfig: fastifyServerConfigProvider,
+        paths: GENERATED_TEMPLATES.paths.provider,
+      },
+      run({ fastifyServerConfig, paths }) {
+        fastifyServerConfig.plugins.set('pgBossPlugin', {
+          plugin: tsCodeFragment(
+            'pgBossPlugin',
+            tsImportBuilder(['pgBossPlugin']).from(paths.pgBossPlugin),
+          ),
+        });
+      },
+    }),
     fastify: createGeneratorTask({
       dependencies: {
         fastify: fastifyProvider,

--- a/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/templates/src/plugins/pg-boss.plugin.ts
+++ b/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/templates/src/plugins/pg-boss.plugin.ts
@@ -8,7 +8,7 @@ import fastifyPlugin from 'fastify-plugin';
 /**
  * Fastify plugin for pg-boss queue system initialization.
  */
-const pgBossPlugin: FastifyPluginAsync = async (fastify) => {
+const pgBossPluginCallback: FastifyPluginAsync = async (fastify) => {
   // Initialize pg-boss in API mode (maintenance disabled)
   await initializePgBoss({ disableMaintenance: true });
 
@@ -18,6 +18,6 @@ const pgBossPlugin: FastifyPluginAsync = async (fastify) => {
   });
 };
 
-export default fastifyPlugin(pgBossPlugin, {
+export const pgBossPlugin = fastifyPlugin(pgBossPluginCallback, {
   name: 'pg-boss',
 });

--- a/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/templates/src/services/pg-boss.service.ts
+++ b/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/templates/src/services/pg-boss.service.ts
@@ -302,9 +302,6 @@ export function createQueue<T>(
   name: string,
   definition: QueueDefinition<T>,
 ): PgBossQueue<T> {
-  // Just ensure pg-boss is initialized
-  getPgBoss();
-
   return new PgBossQueue(name, definition);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Integrates the pg-boss job queue plugin into the example backend server.
  - Generator now auto-registers the pg-boss plugin in the server configuration.

- Refactor
  - Switched the pg-boss plugin to a named export without changing runtime behavior.
  - Deferred queue initialization until first use to reduce side effects.

- Chores
  - Added Prettier ignore for pnpm-lock.yaml in example projects.
  - Updated AI settings to specify the model used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->