### PR TITLE
fix: Fix selection of file transformers in file relation modal

### DIFF
--- a/.changeset/large-dryers-enjoy.md
+++ b/.changeset/large-dryers-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/plugin-storage': patch
+---
+
+Fix selection of file relations in transformer modal

--- a/plugins/plugin-storage/src/storage/transformers/components/file-transformer-form.tsx
+++ b/plugins/plugin-storage/src/storage/transformers/components/file-transformer-form.tsx
@@ -30,7 +30,8 @@ export function FileTransformerForm({
   const controlTyped = control as Control<{
     prefix: FileTransformerDefinition;
   }>;
-  const { definition, pluginContainer } = useProjectDefinition();
+  const { definition, pluginContainer, definitionContainer } =
+    useProjectDefinition();
 
   const storageConfig = PluginUtils.configByKeyOrThrow(
     definition,
@@ -39,7 +40,9 @@ export function FileTransformerForm({
 
   const fileRelations =
     originalModel.model.relations?.filter(
-      (relation) => relation.modelRef === STORAGE_MODELS.file,
+      (relation) =>
+        definitionContainer.nameFromId(relation.modelRef) ===
+        STORAGE_MODELS.file,
     ) ?? [];
 
   const relationOptions = fileRelations.map((relation) => ({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file relation selection in the transformer modal, ensuring the correct file relations are identified and selectable. This improves accuracy and consistency when configuring file transformers.

* **Chores**
  * Prepared a patch release for @baseplate-dev/plugin-storage to deliver the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->