### PR TITLE
fix: Fix setting of max file size MB and allow services with no exposed functions to have transformers

### DIFF
--- a/.changeset/fancy-baths-tap.md
+++ b/.changeset/fancy-baths-tap.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/project-builder-web': patch
+---
+
+Allow services with transformers but no exposed service functions

--- a/.changeset/mean-chefs-eat.md
+++ b/.changeset/mean-chefs-eat.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/plugin-storage': patch
+---
+
+Fix setting of max file size MB in web editor

--- a/packages/project-builder-server/src/compiler/web/index.ts
+++ b/packages/project-builder-server/src/compiler/web/index.ts
@@ -54,7 +54,7 @@ function buildAdminNavigationLinks(
     path: `${adminApp.pathPrefix}/${
       FeatureUtils.getFeatureByIdOrThrow(projectDefinition, section.featureRef)
         .name
-    }/${kebabCase(section.name.toLocaleLowerCase())}`,
+    }/${kebabCase(section.name)}`,
   }));
 }
 

--- a/packages/project-builder-web/src/routes/admin-sections.$appKey/edit.$sectionKey.tsx
+++ b/packages/project-builder-web/src/routes/admin-sections.$appKey/edit.$sectionKey.tsx
@@ -79,7 +79,6 @@ function EditAdminSectionPage(): React.JSX.Element {
   const formProps = useResettableForm({
     resolver: zodResolver(adminSectionSchema),
     values: section,
-    defaultValues: { type: 'crud' },
   });
 
   const { control, handleSubmit, reset } = formProps;

--- a/packages/project-builder-web/src/routes/data/models/-hooks/use-model-form.ts
+++ b/packages/project-builder-web/src/routes/data/models/-hooks/use-model-form.ts
@@ -149,7 +149,8 @@ export function useModelForm({
         if (
           !service.create.enabled &&
           !service.update.enabled &&
-          !service.delete.enabled
+          !service.delete.enabled &&
+          service.transformers.length === 0
         ) {
           updatedModel.service = {
             create: { enabled: false },

--- a/plugins/plugin-storage/src/storage/transformers/schema/file-transformer.schema.ts
+++ b/plugins/plugin-storage/src/storage/transformers/schema/file-transformer.schema.ts
@@ -24,7 +24,7 @@ export const createFileTransformerSchema = definitionSchema((ctx) =>
       }),
       category: z.object({
         name: CASE_VALIDATORS.CONSTANT_CASE,
-        maxFileSizeMb: z.number().int().positive(),
+        maxFileSizeMb: z.coerce.number().int().positive(),
         authorize: z.object({
           uploadRoles: z.array(
             ctx.withRef({

--- a/plugins/plugin-storage/src/storage/transformers/web.ts
+++ b/plugins/plugin-storage/src/storage/transformers/web.ts
@@ -30,6 +30,7 @@ function findNonTransformedFileRelations(
     (transformer): transformer is FileTransformerDefinition =>
       transformer.type === 'file',
   );
+
   return (
     modelConfig.model.relations
       ?.filter(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Web editor now correctly saves “Max File Size (MB)” and accepts numeric-like inputs (e.g., "10").
  * Admin section edit form no longer forces a default type; it respects the existing section’s values.
  * Services with transformers but no exposed methods are preserved instead of being collapsed.

* **Improvements**
  * More consistent admin navigation URLs by refining how section names are converted to paths.

* **Style**
  * Minor whitespace cleanup with no behavioral impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->