### PR TITLE
fix: Handle complex inter deletes via MCP server

### DIFF
--- a/.changeset/eng-1142-cascade-model-relations.md
+++ b/.changeset/eng-1142-cascade-model-relations.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/project-builder-server': patch
+---
+
+Cascade model→model relation deletions when staging a model delete via MCP, so deleting a model auto-removes the relations on other models that referenced it.

--- a/packages/project-builder-server/src/actions/definition/definition-test-fixtures.test-helper.ts
+++ b/packages/project-builder-server/src/actions/definition/definition-test-fixtures.test-helper.ts
@@ -102,6 +102,7 @@ export const test = baseTest.extend<{
           testEntityServiceContext.entityContext.serializedDefinition,
       },
       entityContext: testEntityServiceContext.entityContext,
+      container: testEntityServiceContext.container,
       oldRefPayload: testEntityServiceContext.container.refPayload,
       parserContext: testEntityServiceContext.parserContext,
       projectDirectory: '/test-project',

--- a/packages/project-builder-server/src/actions/definition/draft-lifecycle.int.test.ts
+++ b/packages/project-builder-server/src/actions/definition/draft-lifecycle.int.test.ts
@@ -164,6 +164,7 @@ describe('draft lifecycle', () => {
         draftDefinition: mismatchContext.entityContext.serializedDefinition,
       },
       entityContext: mismatchContext.entityContext,
+      container: mismatchContext.container,
       oldRefPayload: mismatchContext.container.refPayload,
       parserContext: mismatchContext.parserContext,
       projectDirectory: '/test-project',

--- a/packages/project-builder-server/src/actions/definition/draft-session.ts
+++ b/packages/project-builder-server/src/actions/definition/draft-session.ts
@@ -113,6 +113,8 @@ export async function deleteDraftSession(
 export interface DraftSessionContext {
   session: DraftSession;
   entityContext: EntityServiceContext;
+  /** The container built from the current draft definition (resolved, ID-based refs). */
+  container: ProjectDefinitionContainer;
   /** Ref payload from the current draft (before the pending edit), used for rename detection. */
   oldRefPayload: ResolvedZodRefPayload<unknown>;
   parserContext: SchemaParserContext;
@@ -170,6 +172,7 @@ export async function getOrCreateDraftSession(
     return {
       session: existingDraft,
       entityContext,
+      container: draftContainer,
       oldRefPayload: draftContainer.refPayload,
       parserContext,
       projectDirectory: project.directory,
@@ -191,6 +194,7 @@ export async function getOrCreateDraftSession(
   return {
     session,
     entityContext,
+    container,
     oldRefPayload: container.refPayload,
     parserContext,
     projectDirectory: project.directory,

--- a/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.int.test.ts
+++ b/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.int.test.ts
@@ -140,6 +140,18 @@ describe('stage-delete-entity', () => {
           }),
         ],
       },
+      // Expose the relation (and User's inverse foreign relation `author`) in
+      // GraphQL. These hold DELETE_PARENT refs to the relation entities, so the
+      // cascade must clean them up when the relations are deleted — exercising
+      // the regression where strict deserialization would otherwise choke on the
+      // dangling refs.
+      graphql: {
+        objectType: {
+          enabled: true,
+          localRelations: [{ ref: 'user' }],
+          foreignRelations: [{ ref: 'author' }],
+        },
+      },
     });
 
     const testEntityServiceContext = createTestEntityServiceContext({

--- a/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.int.test.ts
+++ b/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.int.test.ts
@@ -1,9 +1,22 @@
+import {
+  createTestFeature,
+  createTestModel,
+  createTestRelationField,
+  createTestScalarField,
+} from '@baseplate-dev/project-builder-lib/testing';
 import { vol } from 'memfs';
 import { readFile } from 'node:fs/promises';
 import { beforeEach, describe, expect, vi } from 'vitest';
 
-import { invokeServiceActionForTest } from '../__tests__/action-test-utils.js';
+import type { DraftSessionContext } from './draft-session.js';
+
+import {
+  createTestActionContext,
+  createTestEntityServiceContext,
+  invokeServiceActionForTest,
+} from '../__tests__/action-test-utils.js';
 import { test } from './definition-test-fixtures.test-helper.js';
+import { getOrCreateDraftSession } from './draft-session.js';
 import { stageDeleteEntityAction } from './stage-delete-entity.action.js';
 
 vi.mock('./load-entity-service-context.js');
@@ -79,5 +92,115 @@ describe('stage-delete-entity', () => {
     const fieldNames = blogPost.model.fields.map((f) => f.name);
     expect(fieldNames).not.toContain('title');
     expect(fieldNames).toContain('content');
+  });
+
+  test('should cascade-delete relations on other models that reference the deleted model', async ({
+    projectDir,
+  }) => {
+    // Two mutually-referencing models: deleting either should not be blocked by
+    // the other's relation (modelRef has onDelete: RESTRICT). The cascade should
+    // remove the incoming relation first, then the model.
+    const feature = createTestFeature({ name: 'blog' });
+
+    const userModel = createTestModel({
+      name: 'User',
+      featureRef: feature.name,
+      model: {
+        fields: [
+          createTestScalarField({ name: 'id', type: 'uuid' }),
+          createTestScalarField({ name: 'postId', type: 'uuid' }),
+        ],
+        primaryKeyFieldRefs: ['id'],
+        relations: [
+          createTestRelationField({
+            name: 'post',
+            modelRef: 'Post',
+            foreignRelationName: 'author',
+            references: [{ localRef: 'postId', foreignRef: 'id' }],
+          }),
+        ],
+      },
+    });
+
+    const postModel = createTestModel({
+      name: 'Post',
+      featureRef: feature.name,
+      model: {
+        fields: [
+          createTestScalarField({ name: 'id', type: 'uuid' }),
+          createTestScalarField({ name: 'userId', type: 'uuid' }),
+        ],
+        primaryKeyFieldRefs: ['id'],
+        relations: [
+          createTestRelationField({
+            name: 'user',
+            modelRef: 'User',
+            foreignRelationName: 'posts',
+            references: [{ localRef: 'userId', foreignRef: 'id' }],
+          }),
+        ],
+      },
+    });
+
+    const testEntityServiceContext = createTestEntityServiceContext({
+      features: [feature],
+      models: [userModel, postModel],
+    });
+
+    const draftSessionContext: DraftSessionContext = {
+      session: {
+        sessionId: 'default',
+        definitionHash: 'test-hash',
+        draftDefinition:
+          testEntityServiceContext.entityContext.serializedDefinition,
+      },
+      entityContext: testEntityServiceContext.entityContext,
+      container: testEntityServiceContext.container,
+      oldRefPayload: testEntityServiceContext.container.refPayload,
+      parserContext: testEntityServiceContext.parserContext,
+      projectDirectory: projectDir,
+    };
+    vi.mocked(getOrCreateDraftSession).mockResolvedValue(draftSessionContext);
+
+    const result = await invokeServiceActionForTest(
+      stageDeleteEntityAction,
+      {
+        project: 'test-project',
+        entityTypeName: 'model',
+        entityId: userModel.id,
+      },
+      createTestActionContext(),
+    );
+
+    // No throw means the RESTRICT block from Post.user -> User was cleared.
+    expect(result.message).toContain('Staged deletion');
+
+    // Warning reported for the cascaded relation on Post.
+    expect(result.issues).toBeDefined();
+    expect(
+      result.issues?.some(
+        (issue) =>
+          issue.severity === 'warning' && issue.message.includes("'user'"),
+      ),
+    ).toBe(true);
+
+    const defContents = await readFile(
+      `${projectDir}/baseplate/.build/draft-definition.json`,
+      'utf-8',
+    );
+    const definition = JSON.parse(defContents) as {
+      models: {
+        name: string;
+        model: { relations?: { name: string }[] };
+      }[];
+    };
+
+    // User model is gone.
+    expect(definition.models.some((m) => m.name === 'User')).toBe(false);
+
+    // Post's relation that referenced User is gone.
+    const post = definition.models.find((m) => m.name === 'Post');
+    expect(post).toBeDefined();
+    expect(post?.model.relations ?? []).toHaveLength(0);
   });
 });

--- a/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.int.test.ts
+++ b/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.int.test.ts
@@ -215,4 +215,22 @@ describe('stage-delete-entity', () => {
     expect(post).toBeDefined();
     expect(post?.model.relations ?? []).toHaveLength(0);
   });
+
+  test('should throw when the model to delete does not exist', async ({
+    context,
+  }) => {
+    // The model branch bypasses deleteEntity, so a missing id must fail fast
+    // rather than silently persisting an unchanged draft.
+    await expect(
+      invokeServiceActionForTest(
+        stageDeleteEntityAction,
+        {
+          project: 'test-project',
+          entityTypeName: 'model',
+          entityId: 'model:does-not-exist',
+        },
+        context,
+      ),
+    ).rejects.toThrow('not found');
+  });
 });

--- a/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.ts
+++ b/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.ts
@@ -1,4 +1,12 @@
-import { deleteEntity } from '@baseplate-dev/project-builder-lib';
+import type { DefinitionIssue } from '@baseplate-dev/project-builder-lib';
+
+import {
+  deleteEntity,
+  modelEntityType,
+  modelLocalRelationEntityType,
+  ModelUtils,
+  ProjectDefinitionContainer,
+} from '@baseplate-dev/project-builder-lib';
 import { z } from 'zod';
 
 import { createServiceAction } from '#src/actions/types.js';
@@ -40,8 +48,77 @@ export const stageDeleteEntityAction = createServiceAction({
   handler: async (input, context) => {
     assertEntityTypeNotBlacklisted(input.entityTypeName);
 
-    const { session, entityContext, parserContext, projectDirectory } =
-      await getOrCreateDraftSession(input.project, context);
+    const {
+      session,
+      entityContext,
+      container,
+      parserContext,
+      projectDirectory,
+    } = await getOrCreateDraftSession(input.project, context);
+
+    // When deleting a model, other models' relations hold an `onDelete: RESTRICT`
+    // reference to it (modelRef), which would block the delete during validation.
+    // Cascade-delete those incoming relations first so the draft stays valid, then
+    // delete the model itself. Each cascaded relation is reported as a warning.
+    const cascadeWarnings: DefinitionIssue[] = [];
+    if (input.entityTypeName === modelEntityType.name) {
+      const incomingRelations = ModelUtils.getRelationsToModel(
+        container.definition,
+        input.entityId,
+      ).filter(({ model }) => model.id !== input.entityId); // self-relations vanish with the model
+
+      for (const { model, relation } of incomingRelations) {
+        cascadeWarnings.push({
+          message: `Auto-deleted relation '${relation.name}' on model '${model.name}' that referenced the deleted model.`,
+          severity: 'warning',
+          entityId: model.id,
+          path: ['model', 'relations'],
+        });
+      }
+
+      // Delete the incoming relation entities sequentially, rebuilding the entity
+      // context after each splice so paths/ids stay accurate (deleteEntity is
+      // immutable and bound to a single container snapshot).
+      let workingDefinition = entityContext.serializedDefinition;
+      let workingContext = entityContext;
+      for (const { relation } of incomingRelations) {
+        workingDefinition = deleteEntity(
+          {
+            entityTypeName: modelLocalRelationEntityType.name,
+            entityId: relation.id,
+          },
+          workingContext,
+        );
+        workingContext = ProjectDefinitionContainer.fromSerializedConfig(
+          workingDefinition,
+          parserContext,
+        ).toEntityServiceContext();
+      }
+
+      const newDefinition = deleteEntity(
+        {
+          entityTypeName: input.entityTypeName,
+          entityId: input.entityId,
+        },
+        workingContext,
+      );
+
+      const { warnings } = await validateAndSaveDraft(
+        newDefinition,
+        parserContext,
+        session,
+        projectDirectory,
+      );
+
+      const allWarnings = [...cascadeWarnings, ...warnings];
+      return {
+        message: `Staged deletion of ${input.entityTypeName} entity "${input.entityId}". Use commit-draft to persist.`,
+        issues:
+          allWarnings.length > 0
+            ? allWarnings.map(mapIssueToOutput)
+            : undefined,
+      };
+    }
 
     const newDefinition = deleteEntity(
       {

--- a/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.ts
+++ b/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.ts
@@ -3,7 +3,6 @@ import type { DefinitionIssue } from '@baseplate-dev/project-builder-lib';
 import {
   deleteEntity,
   modelEntityType,
-  modelLocalRelationEntityType,
   ModelUtils,
   ProjectDefinitionContainer,
 } from '@baseplate-dev/project-builder-lib';
@@ -58,53 +57,60 @@ export const stageDeleteEntityAction = createServiceAction({
 
     // When deleting a model, other models' relations hold an `onDelete: RESTRICT`
     // reference to it (modelRef), which would block the delete during validation.
-    // Cascade-delete those incoming relations first so the draft stays valid, then
-    // delete the model itself. Each cascaded relation is reported as a warning.
-    const cascadeWarnings: DefinitionIssue[] = [];
+    // Cascade-delete those incoming relations together with the model in a single
+    // `fixRefDeletions` pass: removing the relation objects clears the RESTRICTs,
+    // and the GraphQL `localRelations`/`foreignRelations` refs to those relations
+    // (onDelete: DELETE_PARENT) cascade away inside the tolerant fixer. Each
+    // cascaded relation is reported as a warning.
     if (input.entityTypeName === modelEntityType.name) {
       const incomingRelations = ModelUtils.getRelationsToModel(
         container.definition,
         input.entityId,
       ).filter(({ model }) => model.id !== input.entityId); // self-relations vanish with the model
 
-      for (const { model, relation } of incomingRelations) {
-        cascadeWarnings.push({
+      const cascadeWarnings: DefinitionIssue[] = incomingRelations.map(
+        ({ model, relation }) => ({
           message: `Auto-deleted relation '${relation.name}' on model '${model.name}' that referenced the deleted model.`,
           severity: 'warning',
           entityId: model.id,
           path: ['model', 'relations'],
-        });
-      }
-
-      // Delete the incoming relation entities sequentially, rebuilding the entity
-      // context after each splice so paths/ids stay accurate (deleteEntity is
-      // immutable and bound to a single container snapshot).
-      let workingDefinition = entityContext.serializedDefinition;
-      let workingContext = entityContext;
-      for (const { relation } of incomingRelations) {
-        workingDefinition = deleteEntity(
-          {
-            entityTypeName: modelLocalRelationEntityType.name,
-            entityId: relation.id,
-          },
-          workingContext,
-        );
-        workingContext = ProjectDefinitionContainer.fromSerializedConfig(
-          workingDefinition,
-          parserContext,
-        ).toEntityServiceContext();
-      }
-
-      const newDefinition = deleteEntity(
-        {
-          entityTypeName: input.entityTypeName,
-          entityId: input.entityId,
-        },
-        workingContext,
+        }),
       );
 
+      const result = container.fixRefDeletions((draftConfig) => {
+        // Remove relations pointing at the deleted model first, then the model.
+        for (const m of draftConfig.models) {
+          m.model.relations = m.model.relations.filter(
+            (r) => r.modelRef !== input.entityId,
+          );
+        }
+        draftConfig.models = draftConfig.models.filter(
+          (m) => m.id !== input.entityId,
+        );
+      });
+
+      if (result.type === 'failure') {
+        // Any remaining RESTRICT references (e.g. from plugins/services) still block.
+        const messages = result.issues
+          .map(
+            (issue) =>
+              `Cannot delete: referenced by ${issue.ref.path.join('.')} (onDelete: RESTRICT)`,
+          )
+          .join('; ');
+        throw new Error(`Staging blocked by definition errors: ${messages}`);
+      }
+
+      // Rebuild a clean (dangle-free) container from the cascaded result and
+      // serialize it back to a name-based definition for validation + save.
+      const cleanedDefinition = new ProjectDefinitionContainer(
+        result.refPayload,
+        container.parserContext,
+        container.pluginStore,
+        container.schema,
+      ).toEntityServiceContext().serializedDefinition;
+
       const { warnings } = await validateAndSaveDraft(
-        newDefinition,
+        cleanedDefinition,
         parserContext,
         session,
         projectDirectory,

--- a/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.ts
+++ b/packages/project-builder-server/src/actions/definition/stage-delete-entity.action.ts
@@ -63,6 +63,15 @@ export const stageDeleteEntityAction = createServiceAction({
     // (onDelete: DELETE_PARENT) cascade away inside the tolerant fixer. Each
     // cascaded relation is reported as a warning.
     if (input.entityTypeName === modelEntityType.name) {
+      // Fail fast for a missing model: this branch bypasses `deleteEntity` (which
+      // would throw on an unknown id), so without this guard an unknown entityId
+      // would be a silent no-op that still reports a successful delete.
+      if (!ModelUtils.byId(container.definition, input.entityId)) {
+        throw new Error(
+          `Entity "${input.entityId}" of type "${input.entityTypeName}" not found`,
+        );
+      }
+
       const incomingRelations = ModelUtils.getRelationsToModel(
         container.definition,
         input.entityId,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staging a model deletion now automatically removes related references from other models and surfaces warnings about affected relations.
* **Bug Fixes**
  * Deleted models are now cleaned up more reliably during draft updates, reducing validation issues from leftover links.
  * Deletion flows for non-model items continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->