### PR TITLE
feat: Support `Readable` streams in addition to `Buffer` when calling the server-side `uploadFile`

### DIFF
--- a/.changeset/eng-898-uploadfile-readable-stream.md
+++ b/.changeset/eng-898-uploadfile-readable-stream.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/plugin-storage': patch
+---
+
+Support `Readable` streams in addition to `Buffer` when calling the server-side `uploadFile`, enabling streaming uploads without buffering the full file in memory.

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/storage/services/upload-file.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/storage/services/upload-file.ts
@@ -1,3 +1,5 @@
+import type { Readable } from 'node:stream';
+
 import type { File } from '@src/generated/prisma/client.js';
 import type { ServiceContext } from '@src/utils/service-context.js';
 
@@ -10,13 +12,13 @@ import { validateFileUploadOptions } from '../utils/validate-file-upload-options
 /**
  * Uploads a file to storage directly from the server.
  *
- * @param contents - The file contents as a Buffer
+ * @param contents - The file contents as a Buffer or Readable stream
  * @param options - The file upload options (filename, size, contentType, category)
  * @param context - The service context with auth information
  * @returns The uploaded file record
  */
 export async function uploadFile(
-  contents: Buffer,
+  contents: Buffer | Readable,
   options: FileUploadOptions,
   context: ServiceContext,
 ): Promise</* TPL_FILE_MODEL_TYPE:START */ File /* TPL_FILE_MODEL_TYPE:END */> {
@@ -25,19 +27,31 @@ export async function uploadFile(
     context,
   );
 
+  // Create the record as a pending upload first (size unknown until the upload
+  // completes — a Readable has no .length). If the upload or the follow-up
+  // update fails, the row is left as a pending upload and reclaimed by the
+  // cleanUnusedFiles job, so no orphaned storage object is leaked.
   const file =
     await /* TPL_FILE_MODEL:START */ prisma.file /* TPL_FILE_MODEL:END */
       .create({
         data: {
           ...fileCreateInput,
-          pendingUpload: false,
-          size: contents.length,
+          pendingUpload: true,
+          size: null,
         },
       });
 
-  await adapter.uploadFile(file.storagePath, contents, {
+  // Upload and record the actual byte size for both Buffers and streams.
+  const { size } = await adapter.uploadFile(file.storagePath, contents, {
     contentType: options.contentType,
   });
 
-  return file;
+  return /* TPL_FILE_MODEL:START */ prisma.file /* TPL_FILE_MODEL:END */
+    .update({
+      where: { id: file.id },
+      data: {
+        pendingUpload: false,
+        size,
+      },
+    });
 }

--- a/examples/todo-with-better-auth/apps/backend/src/modules/storage/services/upload-file.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/storage/services/upload-file.ts
@@ -1,3 +1,5 @@
+import type { Readable } from 'node:stream';
+
 import type { File } from '@src/generated/prisma/client.js';
 import type { ServiceContext } from '@src/utils/service-context.js';
 
@@ -10,13 +12,13 @@ import { validateFileUploadOptions } from '../utils/validate-file-upload-options
 /**
  * Uploads a file to storage directly from the server.
  *
- * @param contents - The file contents as a Buffer
+ * @param contents - The file contents as a Buffer or Readable stream
  * @param options - The file upload options (filename, size, contentType, category)
  * @param context - The service context with auth information
  * @returns The uploaded file record
  */
 export async function uploadFile(
-  contents: Buffer,
+  contents: Buffer | Readable,
   options: FileUploadOptions,
   context: ServiceContext,
 ): Promise</* TPL_FILE_MODEL_TYPE:START */ File /* TPL_FILE_MODEL_TYPE:END */> {
@@ -25,19 +27,31 @@ export async function uploadFile(
     context,
   );
 
+  // Create the record as a pending upload first (size unknown until the upload
+  // completes — a Readable has no .length). If the upload or the follow-up
+  // update fails, the row is left as a pending upload and reclaimed by the
+  // cleanUnusedFiles job, so no orphaned storage object is leaked.
   const file =
     await /* TPL_FILE_MODEL:START */ prisma.file /* TPL_FILE_MODEL:END */
       .create({
         data: {
           ...fileCreateInput,
-          pendingUpload: false,
-          size: contents.length,
+          pendingUpload: true,
+          size: null,
         },
       });
 
-  await adapter.uploadFile(file.storagePath, contents, {
+  // Upload and record the actual byte size for both Buffers and streams.
+  const { size } = await adapter.uploadFile(file.storagePath, contents, {
     contentType: options.contentType,
   });
 
-  return file;
+  return /* TPL_FILE_MODEL:START */ prisma.file /* TPL_FILE_MODEL:END */
+    .update({
+      where: { id: file.id },
+      data: {
+        pendingUpload: false,
+        size,
+      },
+    });
 }

--- a/plugins/plugin-storage/src/generators/fastify/storage-module/templates/module/services/upload-file.ts
+++ b/plugins/plugin-storage/src/generators/fastify/storage-module/templates/module/services/upload-file.ts
@@ -2,19 +2,20 @@
 
 import type { FileUploadOptions } from '$utilsValidateFileUploadOptions';
 import type { ServiceContext } from '%serviceContextImports';
+import type { Readable } from 'node:stream';
 
 import { validateFileUploadOptions } from '$utilsValidateFileUploadOptions';
 
 /**
  * Uploads a file to storage directly from the server.
  *
- * @param contents - The file contents as a Buffer
+ * @param contents - The file contents as a Buffer or Readable stream
  * @param options - The file upload options (filename, size, contentType, category)
  * @param context - The service context with auth information
  * @returns The uploaded file record
  */
 export async function uploadFile(
-  contents: Buffer,
+  contents: Buffer | Readable,
   options: FileUploadOptions,
   context: ServiceContext,
 ): Promise<TPL_FILE_MODEL_TYPE> {
@@ -23,17 +24,28 @@ export async function uploadFile(
     context,
   );
 
+  // Create the record as a pending upload first (size unknown until the upload
+  // completes — a Readable has no .length). If the upload or the follow-up
+  // update fails, the row is left as a pending upload and reclaimed by the
+  // cleanUnusedFiles job, so no orphaned storage object is leaked.
   const file = await TPL_FILE_MODEL.create({
     data: {
       ...fileCreateInput,
-      pendingUpload: false,
-      size: contents.length,
+      pendingUpload: true,
+      size: null,
     },
   });
 
-  await adapter.uploadFile(file.storagePath, contents, {
+  // Upload and record the actual byte size for both Buffers and streams.
+  const { size } = await adapter.uploadFile(file.storagePath, contents, {
     contentType: options.contentType,
   });
 
-  return file;
+  return TPL_FILE_MODEL.update({
+    where: { id: file.id },
+    data: {
+      pendingUpload: false,
+      size,
+    },
+  });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server-side file uploads now support both `Buffer` and streaming `Readable` input.
  * Uploads can complete without loading the full file into memory first.
* **Bug Fixes**
  * File size is now recorded from the actual uploaded content, improving accuracy.
  * Upload records are updated only after the transfer completes, helping reflect the true upload state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->