### PR TITLE
fix: Route queue job handler failures to error logger

### DIFF
--- a/.changeset/queue-job-failures-sentry.md
+++ b/.changeset/queue-job-failures-sentry.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/plugin-queue': patch
+---
+
+Queue job handler failures are now routed through the configured error logger. Previously, when a queue job threw (for example an email send failure), the error was written to the application logs but bypassed the error-logger service, so any configured external error handlers (such as Sentry) never received it. Both the pg-boss and BullMQ workers now report handler errors via `logError`, so failures reach every configured error handler in addition to the logs.

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/services/pg-boss.service.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/services/pg-boss.service.ts
@@ -255,16 +255,12 @@ export class PgBossQueue<T> implements Queue<T> {
 
           await boss.complete(this.name, job.id, result as object);
         } catch (error: unknown) {
-          logger.error(
-            {
-              queueName: this.name,
-              jobId: job.id,
-              attemptNumber: queueJob.attemptNumber,
-              err: error,
-              event: 'job-processing-failed',
-            },
-            `Job ${job.id} for queue ${this.name} failed`,
-          );
+          logError(error, {
+            queueName: this.name,
+            jobId: job.id,
+            attemptNumber: queueJob.attemptNumber,
+            event: 'job-processing-failed',
+          });
 
           await boss.fail(this.name, job.id, { err: String(error) });
         }

--- a/examples/blog-with-auth/apps/backend/src/services/pg-boss.service.ts
+++ b/examples/blog-with-auth/apps/backend/src/services/pg-boss.service.ts
@@ -255,16 +255,12 @@ export class PgBossQueue<T> implements Queue<T> {
 
           await boss.complete(this.name, job.id, result as object);
         } catch (error: unknown) {
-          logger.error(
-            {
-              queueName: this.name,
-              jobId: job.id,
-              attemptNumber: queueJob.attemptNumber,
-              err: error,
-              event: 'job-processing-failed',
-            },
-            `Job ${job.id} for queue ${this.name} failed`,
-          );
+          logError(error, {
+            queueName: this.name,
+            jobId: job.id,
+            attemptNumber: queueJob.attemptNumber,
+            event: 'job-processing-failed',
+          });
 
           await boss.fail(this.name, job.id, { err: String(error) });
         }

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/services/bullmq.service.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/services/bullmq.service.ts
@@ -282,16 +282,12 @@ export class BullMQQueue<T> implements Queue<T> {
 
           return result;
         } catch (error: unknown) {
-          logger.error(
-            {
-              queueName: this.name,
-              jobId: job.id,
-              attemptNumber: queueJob.attemptNumber,
-              err: error,
-              event: 'job-processing-failed',
-            },
-            `Job ${job.id} for queue ${this.name} failed`,
-          );
+          logError(error, {
+            queueName: this.name,
+            jobId: job.id,
+            attemptNumber: queueJob.attemptNumber,
+            event: 'job-processing-failed',
+          });
 
           throw error;
         }

--- a/examples/todo-with-better-auth/apps/backend/src/services/bullmq.service.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/services/bullmq.service.ts
@@ -282,16 +282,12 @@ export class BullMQQueue<T> implements Queue<T> {
 
           return result;
         } catch (error: unknown) {
-          logger.error(
-            {
-              queueName: this.name,
-              jobId: job.id,
-              attemptNumber: queueJob.attemptNumber,
-              err: error,
-              event: 'job-processing-failed',
-            },
-            `Job ${job.id} for queue ${this.name} failed`,
-          );
+          logError(error, {
+            queueName: this.name,
+            jobId: job.id,
+            attemptNumber: queueJob.attemptNumber,
+            event: 'job-processing-failed',
+          });
 
           throw error;
         }

--- a/plugins/plugin-queue/src/bullmq/core/generators/bullmq/templates/src/services/bullmq.service.ts
+++ b/plugins/plugin-queue/src/bullmq/core/generators/bullmq/templates/src/services/bullmq.service.ts
@@ -282,16 +282,12 @@ export class BullMQQueue<T> implements Queue<T> {
 
           return result;
         } catch (error: unknown) {
-          logger.error(
-            {
-              queueName: this.name,
-              jobId: job.id,
-              attemptNumber: queueJob.attemptNumber,
-              err: error,
-              event: 'job-processing-failed',
-            },
-            `Job ${job.id} for queue ${this.name} failed`,
-          );
+          logError(error, {
+            queueName: this.name,
+            jobId: job.id,
+            attemptNumber: queueJob.attemptNumber,
+            event: 'job-processing-failed',
+          });
 
           throw error;
         }

--- a/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/templates/src/services/pg-boss.service.ts
+++ b/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/templates/src/services/pg-boss.service.ts
@@ -256,16 +256,12 @@ export class PgBossQueue<T> implements Queue<T> {
 
           await boss.complete(this.name, job.id, result as object);
         } catch (error: unknown) {
-          logger.error(
-            {
-              queueName: this.name,
-              jobId: job.id,
-              attemptNumber: queueJob.attemptNumber,
-              err: error,
-              event: 'job-processing-failed',
-            },
-            `Job ${job.id} for queue ${this.name} failed`,
-          );
+          logError(error, {
+            queueName: this.name,
+            jobId: job.id,
+            attemptNumber: queueJob.attemptNumber,
+            event: 'job-processing-failed',
+          });
 
           await boss.fail(this.name, job.id, { err: String(error) });
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Queue job handler failures are now reported through the configured error logger, so external monitoring can capture them.
  * Failure reporting now includes queue, job, and attempt details for both pg-boss and BullMQ workers.

* **Chores**
  * Published a patch update for the queue plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->