### PR TITLE
feat: Support queue deduplication by key

### DIFF
--- a/.changeset/queue-enqueue-deduplication.md
+++ b/.changeset/queue-enqueue-deduplication.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/plugin-queue': patch
+---
+
+Queues can now deduplicate jobs by key, making enqueueing idempotent when a caller may retry. Set `deduplication: true` in a queue definition's options and pass a `singletonKey` when enqueueing: while a job with that key is pending or active, further enqueues with the same key are dropped instead of creating a duplicate job. The key is released once the job completes or fails, so a later enqueue with the same key creates a new job.

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/services/pg-boss.service.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/services/pg-boss.service.ts
@@ -82,12 +82,39 @@ function getPgBoss(): PgBoss {
 }
 
 /**
+ * Ensure a deduplicated queue is never enqueued to without a singleton key.
+ *
+ * pg-boss deduplicates on `COALESCE(singleton_key, '')`, so jobs enqueued
+ * without a key would all share the empty key and collide with each other,
+ * silently limiting the queue to a single pending job.
+ *
+ * @param queueName The name of the queue.
+ * @param definition The queue definition.
+ * @param singletonKey The resolved singleton key for this job, if any.
+ */
+function assertSingletonKeyIfDeduplicated<T>(
+  queueName: string,
+  definition: QueueDefinition<T>,
+  singletonKey: string | undefined,
+): void {
+  if (definition.options?.deduplication && singletonKey === undefined) {
+    throw new Error(
+      `Queue "${queueName}" has deduplication enabled, so every job must be enqueued with a singletonKey.`,
+    );
+  }
+}
+
+/**
  * Convert our EnqueueOptions to pg-boss send options.
  * @param options The enqueue options from our interface.
  * @returns pg-boss send options.
  */
 function mapEnqueueOptions(options?: EnqueueOptions): PgBoss.SendOptions {
   const pgBossOptions: PgBoss.SendOptions = {};
+
+  if (options?.singletonKey !== undefined) {
+    pgBossOptions.singletonKey = options.singletonKey;
+  }
 
   if (options?.delaySeconds) {
     pgBossOptions.startAfter = new Date(
@@ -175,6 +202,11 @@ export class PgBossQueue<T> implements Queue<T> {
     const boss = getPgBoss();
     await boss.createQueue(this.name, {
       deleteAfterSeconds: DELETE_AFTER_DAYS * 24 * 60 * 60,
+      // pg-boss only deduplicates by singletonKey when the queue uses a policy
+      // that enforces it. `exclusive` rejects a job whose singletonKey matches
+      // one that is already pending or active; the default `standard` policy
+      // ignores singletonKey entirely. The policy is fixed at creation time.
+      ...(this.definition.options?.deduplication && { policy: 'exclusive' }),
     });
     this.hasCreatedQueue = true;
   }
@@ -193,7 +225,15 @@ export class PgBossQueue<T> implements Queue<T> {
       ...options,
     };
 
+    assertSingletonKeyIfDeduplicated(
+      this.name,
+      this.definition,
+      mergedOptions.singletonKey,
+    );
+
     const pgBossOptions = mapEnqueueOptions(mergedOptions);
+    // Returns null when a job with the same singletonKey is already pending or
+    // active on a deduplicated queue, i.e. the job was intentionally dropped.
     const jobId = await boss.send(this.name, data as object, pgBossOptions);
 
     return jobId ?? undefined;

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/types/queue.types.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/types/queue.types.ts
@@ -30,6 +30,16 @@ export interface Queue<T> {
  */
 export interface EnqueueOptions {
   /**
+   * Deduplication key, making enqueueing idempotent when a caller may retry.
+   * While a job with this key is pending or active, further enqueues with the
+   * same key are dropped; the key is released once the job completes or fails.
+   *
+   * Requires `deduplication: true` on the queue, which then requires a key on
+   * every enqueue. The return value of `enqueue` cannot be used to detect a
+   * dropped job, as it differs by backend.
+   */
+  singletonKey?: string;
+  /**
    * The amount of time in seconds to delay before the job can be processed.
    */
   delaySeconds?: number;
@@ -85,11 +95,24 @@ export interface QueueDefinition<T> {
    */
   options?: {
     /**
+     * Deduplicate jobs in this queue by `singletonKey`, which every enqueue must
+     * then supply. See `EnqueueOptions.singletonKey`.
+     *
+     * Must be set before the queue is first created: pg-boss fixes a queue's
+     * deduplication behavior at creation time, so enabling this on an
+     * already-deployed queue has no effect until that queue is recreated.
+     */
+    deduplication?: boolean;
+
+    /**
      * Default options to apply to all jobs in this queue.
      * These can be overridden by the options passed to `enqueue`.
-     * Note: `delaySeconds` is not included as it's typically job-specific.
+     * Note: `delaySeconds` is not included as it's typically job-specific, and
+     * `singletonKey` is not included as a deduplication key is inherently
+     * per-job — sharing one across every job would collapse the queue to a
+     * single job at a time.
      */
-    defaultJobOptions?: Omit<EnqueueOptions, 'delaySeconds'>;
+    defaultJobOptions?: Omit<EnqueueOptions, 'delaySeconds' | 'singletonKey'>;
   };
 }
 

--- a/examples/blog-with-auth/apps/backend/src/services/pg-boss.service.ts
+++ b/examples/blog-with-auth/apps/backend/src/services/pg-boss.service.ts
@@ -82,12 +82,39 @@ function getPgBoss(): PgBoss {
 }
 
 /**
+ * Ensure a deduplicated queue is never enqueued to without a singleton key.
+ *
+ * pg-boss deduplicates on `COALESCE(singleton_key, '')`, so jobs enqueued
+ * without a key would all share the empty key and collide with each other,
+ * silently limiting the queue to a single pending job.
+ *
+ * @param queueName The name of the queue.
+ * @param definition The queue definition.
+ * @param singletonKey The resolved singleton key for this job, if any.
+ */
+function assertSingletonKeyIfDeduplicated<T>(
+  queueName: string,
+  definition: QueueDefinition<T>,
+  singletonKey: string | undefined,
+): void {
+  if (definition.options?.deduplication && singletonKey === undefined) {
+    throw new Error(
+      `Queue "${queueName}" has deduplication enabled, so every job must be enqueued with a singletonKey.`,
+    );
+  }
+}
+
+/**
  * Convert our EnqueueOptions to pg-boss send options.
  * @param options The enqueue options from our interface.
  * @returns pg-boss send options.
  */
 function mapEnqueueOptions(options?: EnqueueOptions): PgBoss.SendOptions {
   const pgBossOptions: PgBoss.SendOptions = {};
+
+  if (options?.singletonKey !== undefined) {
+    pgBossOptions.singletonKey = options.singletonKey;
+  }
 
   if (options?.delaySeconds) {
     pgBossOptions.startAfter = new Date(
@@ -175,6 +202,11 @@ export class PgBossQueue<T> implements Queue<T> {
     const boss = getPgBoss();
     await boss.createQueue(this.name, {
       deleteAfterSeconds: DELETE_AFTER_DAYS * 24 * 60 * 60,
+      // pg-boss only deduplicates by singletonKey when the queue uses a policy
+      // that enforces it. `exclusive` rejects a job whose singletonKey matches
+      // one that is already pending or active; the default `standard` policy
+      // ignores singletonKey entirely. The policy is fixed at creation time.
+      ...(this.definition.options?.deduplication && { policy: 'exclusive' }),
     });
     this.hasCreatedQueue = true;
   }
@@ -193,7 +225,15 @@ export class PgBossQueue<T> implements Queue<T> {
       ...options,
     };
 
+    assertSingletonKeyIfDeduplicated(
+      this.name,
+      this.definition,
+      mergedOptions.singletonKey,
+    );
+
     const pgBossOptions = mapEnqueueOptions(mergedOptions);
+    // Returns null when a job with the same singletonKey is already pending or
+    // active on a deduplicated queue, i.e. the job was intentionally dropped.
     const jobId = await boss.send(this.name, data as object, pgBossOptions);
 
     return jobId ?? undefined;

--- a/examples/blog-with-auth/apps/backend/src/types/queue.types.ts
+++ b/examples/blog-with-auth/apps/backend/src/types/queue.types.ts
@@ -30,6 +30,16 @@ export interface Queue<T> {
  */
 export interface EnqueueOptions {
   /**
+   * Deduplication key, making enqueueing idempotent when a caller may retry.
+   * While a job with this key is pending or active, further enqueues with the
+   * same key are dropped; the key is released once the job completes or fails.
+   *
+   * Requires `deduplication: true` on the queue, which then requires a key on
+   * every enqueue. The return value of `enqueue` cannot be used to detect a
+   * dropped job, as it differs by backend.
+   */
+  singletonKey?: string;
+  /**
    * The amount of time in seconds to delay before the job can be processed.
    */
   delaySeconds?: number;
@@ -85,11 +95,24 @@ export interface QueueDefinition<T> {
    */
   options?: {
     /**
+     * Deduplicate jobs in this queue by `singletonKey`, which every enqueue must
+     * then supply. See `EnqueueOptions.singletonKey`.
+     *
+     * Must be set before the queue is first created: pg-boss fixes a queue's
+     * deduplication behavior at creation time, so enabling this on an
+     * already-deployed queue has no effect until that queue is recreated.
+     */
+    deduplication?: boolean;
+
+    /**
      * Default options to apply to all jobs in this queue.
      * These can be overridden by the options passed to `enqueue`.
-     * Note: `delaySeconds` is not included as it's typically job-specific.
+     * Note: `delaySeconds` is not included as it's typically job-specific, and
+     * `singletonKey` is not included as a deduplication key is inherently
+     * per-job — sharing one across every job would collapse the queue to a
+     * single job at a time.
      */
-    defaultJobOptions?: Omit<EnqueueOptions, 'delaySeconds'>;
+    defaultJobOptions?: Omit<EnqueueOptions, 'delaySeconds' | 'singletonKey'>;
   };
 }
 

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/services/bullmq.service.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/services/bullmq.service.ts
@@ -82,6 +82,29 @@ function getBullMQRedis(): ReturnType<typeof createRedisClient> {
  * @param options The enqueue options from our interface.
  * @returns BullMQ job options.
  */
+/**
+ * Ensure a deduplicated queue is never enqueued to without a singleton key.
+ *
+ * Enqueueing without a key on a deduplicated queue is almost always a mistake:
+ * the job silently bypasses deduplication entirely, so callers relying on
+ * idempotency would get duplicate jobs.
+ *
+ * @param queueName The name of the queue.
+ * @param definition The queue definition.
+ * @param singletonKey The resolved singleton key for this job, if any.
+ */
+function assertSingletonKeyIfDeduplicated<T>(
+  queueName: string,
+  definition: QueueDefinition<T>,
+  singletonKey: string | undefined,
+): void {
+  if (definition.options?.deduplication && singletonKey === undefined) {
+    throw new Error(
+      `Queue "${queueName}" has deduplication enabled, so every job must be enqueued with a singletonKey.`,
+    );
+  }
+}
+
 function mapEnqueueOptions(options?: EnqueueOptions): JobsOptions {
   const bullMQOptions: JobsOptions = {
     // Keep completed jobs for specified days
@@ -92,6 +115,14 @@ function mapEnqueueOptions(options?: EnqueueOptions): JobsOptions {
     // Keep failed jobs for manual inspection
     removeOnFail: false,
   };
+
+  if (options?.singletonKey !== undefined) {
+    // No ttl: BullMQ holds the deduplication key until the job moves to
+    // completed or failed, so jobs are deduplicated while pending or active.
+    // Setting a ttl would instead keep the key alive past completion, turning
+    // this into time-window throttling.
+    bullMQOptions.deduplication = { id: options.singletonKey };
+  }
 
   if (options?.delaySeconds) {
     bullMQOptions.delay = options.delaySeconds * 1000; // Convert to milliseconds
@@ -219,7 +250,17 @@ export class BullMQQueue<T> implements Queue<T> {
       ...options,
     };
 
+    assertSingletonKeyIfDeduplicated(
+      this.name,
+      this.definition,
+      mergedOptions.singletonKey,
+    );
+
     const bullMQOptions = mapEnqueueOptions(mergedOptions);
+    // When a job is deduplicated, BullMQ does not store it and instead returns
+    // the id of the job that is already in flight, so the id below may belong to
+    // that existing job rather than a newly created one. Callers must not treat
+    // the returned id as proof that a new job was created.
     const job = await this.getBullQueue().add(this.name, data, bullMQOptions);
 
     return job.id;

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/types/queue.types.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/types/queue.types.ts
@@ -30,6 +30,16 @@ export interface Queue<T> {
  */
 export interface EnqueueOptions {
   /**
+   * Deduplication key, making enqueueing idempotent when a caller may retry.
+   * While a job with this key is pending or active, further enqueues with the
+   * same key are dropped; the key is released once the job completes or fails.
+   *
+   * Requires `deduplication: true` on the queue, which then requires a key on
+   * every enqueue. The return value of `enqueue` cannot be used to detect a
+   * dropped job, as it differs by backend.
+   */
+  singletonKey?: string;
+  /**
    * The amount of time in seconds to delay before the job can be processed.
    */
   delaySeconds?: number;
@@ -85,11 +95,24 @@ export interface QueueDefinition<T> {
    */
   options?: {
     /**
+     * Deduplicate jobs in this queue by `singletonKey`, which every enqueue must
+     * then supply. See `EnqueueOptions.singletonKey`.
+     *
+     * Must be set before the queue is first created: pg-boss fixes a queue's
+     * deduplication behavior at creation time, so enabling this on an
+     * already-deployed queue has no effect until that queue is recreated.
+     */
+    deduplication?: boolean;
+
+    /**
      * Default options to apply to all jobs in this queue.
      * These can be overridden by the options passed to `enqueue`.
-     * Note: `delaySeconds` is not included as it's typically job-specific.
+     * Note: `delaySeconds` is not included as it's typically job-specific, and
+     * `singletonKey` is not included as a deduplication key is inherently
+     * per-job — sharing one across every job would collapse the queue to a
+     * single job at a time.
      */
-    defaultJobOptions?: Omit<EnqueueOptions, 'delaySeconds'>;
+    defaultJobOptions?: Omit<EnqueueOptions, 'delaySeconds' | 'singletonKey'>;
   };
 }
 

--- a/examples/todo-with-better-auth/apps/backend/src/services/bullmq.service.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/services/bullmq.service.ts
@@ -82,6 +82,29 @@ function getBullMQRedis(): ReturnType<typeof createRedisClient> {
  * @param options The enqueue options from our interface.
  * @returns BullMQ job options.
  */
+/**
+ * Ensure a deduplicated queue is never enqueued to without a singleton key.
+ *
+ * Enqueueing without a key on a deduplicated queue is almost always a mistake:
+ * the job silently bypasses deduplication entirely, so callers relying on
+ * idempotency would get duplicate jobs.
+ *
+ * @param queueName The name of the queue.
+ * @param definition The queue definition.
+ * @param singletonKey The resolved singleton key for this job, if any.
+ */
+function assertSingletonKeyIfDeduplicated<T>(
+  queueName: string,
+  definition: QueueDefinition<T>,
+  singletonKey: string | undefined,
+): void {
+  if (definition.options?.deduplication && singletonKey === undefined) {
+    throw new Error(
+      `Queue "${queueName}" has deduplication enabled, so every job must be enqueued with a singletonKey.`,
+    );
+  }
+}
+
 function mapEnqueueOptions(options?: EnqueueOptions): JobsOptions {
   const bullMQOptions: JobsOptions = {
     // Keep completed jobs for specified days
@@ -92,6 +115,14 @@ function mapEnqueueOptions(options?: EnqueueOptions): JobsOptions {
     // Keep failed jobs for manual inspection
     removeOnFail: false,
   };
+
+  if (options?.singletonKey !== undefined) {
+    // No ttl: BullMQ holds the deduplication key until the job moves to
+    // completed or failed, so jobs are deduplicated while pending or active.
+    // Setting a ttl would instead keep the key alive past completion, turning
+    // this into time-window throttling.
+    bullMQOptions.deduplication = { id: options.singletonKey };
+  }
 
   if (options?.delaySeconds) {
     bullMQOptions.delay = options.delaySeconds * 1000; // Convert to milliseconds
@@ -219,7 +250,17 @@ export class BullMQQueue<T> implements Queue<T> {
       ...options,
     };
 
+    assertSingletonKeyIfDeduplicated(
+      this.name,
+      this.definition,
+      mergedOptions.singletonKey,
+    );
+
     const bullMQOptions = mapEnqueueOptions(mergedOptions);
+    // When a job is deduplicated, BullMQ does not store it and instead returns
+    // the id of the job that is already in flight, so the id below may belong to
+    // that existing job rather than a newly created one. Callers must not treat
+    // the returned id as proof that a new job was created.
     const job = await this.getBullQueue().add(this.name, data, bullMQOptions);
 
     return job.id;

--- a/examples/todo-with-better-auth/apps/backend/src/types/queue.types.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/types/queue.types.ts
@@ -30,6 +30,16 @@ export interface Queue<T> {
  */
 export interface EnqueueOptions {
   /**
+   * Deduplication key, making enqueueing idempotent when a caller may retry.
+   * While a job with this key is pending or active, further enqueues with the
+   * same key are dropped; the key is released once the job completes or fails.
+   *
+   * Requires `deduplication: true` on the queue, which then requires a key on
+   * every enqueue. The return value of `enqueue` cannot be used to detect a
+   * dropped job, as it differs by backend.
+   */
+  singletonKey?: string;
+  /**
    * The amount of time in seconds to delay before the job can be processed.
    */
   delaySeconds?: number;
@@ -85,11 +95,24 @@ export interface QueueDefinition<T> {
    */
   options?: {
     /**
+     * Deduplicate jobs in this queue by `singletonKey`, which every enqueue must
+     * then supply. See `EnqueueOptions.singletonKey`.
+     *
+     * Must be set before the queue is first created: pg-boss fixes a queue's
+     * deduplication behavior at creation time, so enabling this on an
+     * already-deployed queue has no effect until that queue is recreated.
+     */
+    deduplication?: boolean;
+
+    /**
      * Default options to apply to all jobs in this queue.
      * These can be overridden by the options passed to `enqueue`.
-     * Note: `delaySeconds` is not included as it's typically job-specific.
+     * Note: `delaySeconds` is not included as it's typically job-specific, and
+     * `singletonKey` is not included as a deduplication key is inherently
+     * per-job — sharing one across every job would collapse the queue to a
+     * single job at a time.
      */
-    defaultJobOptions?: Omit<EnqueueOptions, 'delaySeconds'>;
+    defaultJobOptions?: Omit<EnqueueOptions, 'delaySeconds' | 'singletonKey'>;
   };
 }
 

--- a/plugins/plugin-queue/src/bullmq/core/generators/bullmq/templates/src/services/bullmq.service.ts
+++ b/plugins/plugin-queue/src/bullmq/core/generators/bullmq/templates/src/services/bullmq.service.ts
@@ -82,6 +82,29 @@ function getBullMQRedis(): ReturnType<typeof createRedisClient> {
  * @param options The enqueue options from our interface.
  * @returns BullMQ job options.
  */
+/**
+ * Ensure a deduplicated queue is never enqueued to without a singleton key.
+ *
+ * Enqueueing without a key on a deduplicated queue is almost always a mistake:
+ * the job silently bypasses deduplication entirely, so callers relying on
+ * idempotency would get duplicate jobs.
+ *
+ * @param queueName The name of the queue.
+ * @param definition The queue definition.
+ * @param singletonKey The resolved singleton key for this job, if any.
+ */
+function assertSingletonKeyIfDeduplicated<T>(
+  queueName: string,
+  definition: QueueDefinition<T>,
+  singletonKey: string | undefined,
+): void {
+  if (definition.options?.deduplication && singletonKey === undefined) {
+    throw new Error(
+      `Queue "${queueName}" has deduplication enabled, so every job must be enqueued with a singletonKey.`,
+    );
+  }
+}
+
 function mapEnqueueOptions(options?: EnqueueOptions): JobsOptions {
   const bullMQOptions: JobsOptions = {
     // Keep completed jobs for specified days
@@ -92,6 +115,14 @@ function mapEnqueueOptions(options?: EnqueueOptions): JobsOptions {
     // Keep failed jobs for manual inspection
     removeOnFail: false,
   };
+
+  if (options?.singletonKey !== undefined) {
+    // No ttl: BullMQ holds the deduplication key until the job moves to
+    // completed or failed, so jobs are deduplicated while pending or active.
+    // Setting a ttl would instead keep the key alive past completion, turning
+    // this into time-window throttling.
+    bullMQOptions.deduplication = { id: options.singletonKey };
+  }
 
   if (options?.delaySeconds) {
     bullMQOptions.delay = options.delaySeconds * 1000; // Convert to milliseconds
@@ -219,7 +250,17 @@ export class BullMQQueue<T> implements Queue<T> {
       ...options,
     };
 
+    assertSingletonKeyIfDeduplicated(
+      this.name,
+      this.definition,
+      mergedOptions.singletonKey,
+    );
+
     const bullMQOptions = mapEnqueueOptions(mergedOptions);
+    // When a job is deduplicated, BullMQ does not store it and instead returns
+    // the id of the job that is already in flight, so the id below may belong to
+    // that existing job rather than a newly created one. Callers must not treat
+    // the returned id as proof that a new job was created.
     const job = await this.getBullQueue().add(this.name, data, bullMQOptions);
 
     return job.id;

--- a/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/templates/src/services/pg-boss.service.ts
+++ b/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/templates/src/services/pg-boss.service.ts
@@ -83,12 +83,39 @@ function getPgBoss(): PgBoss {
 }
 
 /**
+ * Ensure a deduplicated queue is never enqueued to without a singleton key.
+ *
+ * pg-boss deduplicates on `COALESCE(singleton_key, '')`, so jobs enqueued
+ * without a key would all share the empty key and collide with each other,
+ * silently limiting the queue to a single pending job.
+ *
+ * @param queueName The name of the queue.
+ * @param definition The queue definition.
+ * @param singletonKey The resolved singleton key for this job, if any.
+ */
+function assertSingletonKeyIfDeduplicated<T>(
+  queueName: string,
+  definition: QueueDefinition<T>,
+  singletonKey: string | undefined,
+): void {
+  if (definition.options?.deduplication && singletonKey === undefined) {
+    throw new Error(
+      `Queue "${queueName}" has deduplication enabled, so every job must be enqueued with a singletonKey.`,
+    );
+  }
+}
+
+/**
  * Convert our EnqueueOptions to pg-boss send options.
  * @param options The enqueue options from our interface.
  * @returns pg-boss send options.
  */
 function mapEnqueueOptions(options?: EnqueueOptions): PgBoss.SendOptions {
   const pgBossOptions: PgBoss.SendOptions = {};
+
+  if (options?.singletonKey !== undefined) {
+    pgBossOptions.singletonKey = options.singletonKey;
+  }
 
   if (options?.delaySeconds) {
     pgBossOptions.startAfter = new Date(
@@ -176,6 +203,11 @@ export class PgBossQueue<T> implements Queue<T> {
     const boss = getPgBoss();
     await boss.createQueue(this.name, {
       deleteAfterSeconds: DELETE_AFTER_DAYS * 24 * 60 * 60,
+      // pg-boss only deduplicates by singletonKey when the queue uses a policy
+      // that enforces it. `exclusive` rejects a job whose singletonKey matches
+      // one that is already pending or active; the default `standard` policy
+      // ignores singletonKey entirely. The policy is fixed at creation time.
+      ...(this.definition.options?.deduplication && { policy: 'exclusive' }),
     });
     this.hasCreatedQueue = true;
   }
@@ -194,7 +226,15 @@ export class PgBossQueue<T> implements Queue<T> {
       ...options,
     };
 
+    assertSingletonKeyIfDeduplicated(
+      this.name,
+      this.definition,
+      mergedOptions.singletonKey,
+    );
+
     const pgBossOptions = mapEnqueueOptions(mergedOptions);
+    // Returns null when a job with the same singletonKey is already pending or
+    // active on a deduplicated queue, i.e. the job was intentionally dropped.
     const jobId = await boss.send(this.name, data as object, pgBossOptions);
 
     return jobId ?? undefined;

--- a/plugins/plugin-queue/src/queue/core/generators/queues/templates/src/types/queue.types.ts
+++ b/plugins/plugin-queue/src/queue/core/generators/queues/templates/src/types/queue.types.ts
@@ -32,6 +32,16 @@ export interface Queue<T> {
  */
 export interface EnqueueOptions {
   /**
+   * Deduplication key, making enqueueing idempotent when a caller may retry.
+   * While a job with this key is pending or active, further enqueues with the
+   * same key are dropped; the key is released once the job completes or fails.
+   *
+   * Requires `deduplication: true` on the queue, which then requires a key on
+   * every enqueue. The return value of `enqueue` cannot be used to detect a
+   * dropped job, as it differs by backend.
+   */
+  singletonKey?: string;
+  /**
    * The amount of time in seconds to delay before the job can be processed.
    */
   delaySeconds?: number;
@@ -87,11 +97,24 @@ export interface QueueDefinition<T> {
    */
   options?: {
     /**
+     * Deduplicate jobs in this queue by `singletonKey`, which every enqueue must
+     * then supply. See `EnqueueOptions.singletonKey`.
+     *
+     * Must be set before the queue is first created: pg-boss fixes a queue's
+     * deduplication behavior at creation time, so enabling this on an
+     * already-deployed queue has no effect until that queue is recreated.
+     */
+    deduplication?: boolean;
+
+    /**
      * Default options to apply to all jobs in this queue.
      * These can be overridden by the options passed to `enqueue`.
-     * Note: `delaySeconds` is not included as it's typically job-specific.
+     * Note: `delaySeconds` is not included as it's typically job-specific, and
+     * `singletonKey` is not included as a deduplication key is inherently
+     * per-job — sharing one across every job would collapse the queue to a
+     * single job at a time.
      */
-    defaultJobOptions?: Omit<EnqueueOptions, 'delaySeconds'>;
+    defaultJobOptions?: Omit<EnqueueOptions, 'delaySeconds' | 'singletonKey'>;
   };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional queue job deduplication using a `singletonKey`.
  * Duplicate jobs with the same key are ignored while an existing job is pending or active.
  * Keys become available again after the job completes or fails.
  * Supported queue backends now preserve deduplication behavior consistently.

* **Bug Fixes**
  * Enabling deduplication now requires each enqueued job to provide a `singletonKey`, preventing unintended job suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->