### PR TITLE
fix: Removed the `preinstall: npx only-allow pnpm` script from generated `package.json` files

### DIFF
--- a/.changeset/eng-1167-remove-preinstall-only-allow.md
+++ b/.changeset/eng-1167-remove-preinstall-only-allow.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/core-generators': patch
+---
+
+Removed the `preinstall: npx only-allow pnpm` script from generated `package.json` files. Package manager enforcement is already handled via the `packageManager` field, making this script redundant.

--- a/examples/blog-with-auth/apps/admin/baseplate/generated/package.json
+++ b/examples/blog-with-auth/apps/admin/baseplate/generated/package.json
@@ -13,7 +13,6 @@
     "dev": "vite",
     "gql:generate": "graphql-codegen",
     "gql:watch": "graphql-codegen --watch",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/blog-with-auth/apps/admin/package.json
+++ b/examples/blog-with-auth/apps/admin/package.json
@@ -13,7 +13,6 @@
     "dev": "vite",
     "gql:generate": "graphql-codegen",
     "gql:watch": "graphql-codegen --watch",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/package.json
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/package.json
@@ -17,7 +17,6 @@
     "dev:server": "tsx watch --ignore /**/node_modules/** --clear-screen=false --env-file-if-exists=.env --env-file-if-exists=.env.local --import ./src/instrument.ts src/index.ts | pino-pretty -t",
     "dev:workers": "tsx watch --ignore /**/node_modules/** --clear-screen=false --env-file-if-exists=.env --env-file-if-exists=.env.local --import ./src/instrument.ts src/scripts/run-workers.ts | pino-pretty -t",
     "generate:schema": "tsx --env-file-if-exists=.env --env-file-if-exists=.env.local src/index.ts --exit-after-generate-schema",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/blog-with-auth/apps/backend/package.json
+++ b/examples/blog-with-auth/apps/backend/package.json
@@ -17,7 +17,6 @@
     "dev:server": "tsx watch --ignore /**/node_modules/** --clear-screen=false --env-file-if-exists=.env --env-file-if-exists=.env.local --import ./src/instrument.ts src/index.ts | pino-pretty -t",
     "dev:workers": "tsx watch --ignore /**/node_modules/** --clear-screen=false --env-file-if-exists=.env --env-file-if-exists=.env.local --import ./src/instrument.ts src/scripts/run-workers.ts | pino-pretty -t",
     "generate:schema": "tsx --env-file-if-exists=.env --env-file-if-exists=.env.local src/index.ts --exit-after-generate-schema",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/blog-with-auth/baseplate/generated/package.json
+++ b/examples/blog-with-auth/baseplate/generated/package.json
@@ -12,7 +12,6 @@
     "build:affected": "turbo run build --affected",
     "check": "turbo run lint prettier:check test typecheck --affected --continue",
     "dev": "turbo run dev gql:watch watch",
-    "preinstall": "npx only-allow pnpm",
     "lint": "turbo run lint",
     "lint:affected": "turbo run lint --affected",
     "prettier:check": "turbo run prettier:check && pnpm run prettier:check:root",

--- a/examples/blog-with-auth/libs/transactional/baseplate/generated/package.json
+++ b/examples/blog-with-auth/libs/transactional/baseplate/generated/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/blog-with-auth/libs/transactional/package.json
+++ b/examples/blog-with-auth/libs/transactional/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/blog-with-auth/package.json
+++ b/examples/blog-with-auth/package.json
@@ -12,7 +12,6 @@
     "build:affected": "turbo run build --affected",
     "check": "turbo run lint prettier:check test typecheck --affected --continue",
     "dev": "turbo run dev gql:watch watch",
-    "preinstall": "npx only-allow pnpm",
     "lint": "turbo run lint",
     "lint:affected": "turbo run lint --affected",
     "prettier:check": "turbo run prettier:check && pnpm run prettier:check:root",

--- a/examples/todo-with-better-auth/apps/admin/baseplate/generated/package.json
+++ b/examples/todo-with-better-auth/apps/admin/baseplate/generated/package.json
@@ -13,7 +13,6 @@
     "dev": "vite",
     "gql:generate": "graphql-codegen",
     "gql:watch": "graphql-codegen --watch",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/todo-with-better-auth/apps/admin/package.json
+++ b/examples/todo-with-better-auth/apps/admin/package.json
@@ -13,7 +13,6 @@
     "dev": "vite",
     "gql:generate": "graphql-codegen",
     "gql:watch": "graphql-codegen --watch",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/package.json
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/package.json
@@ -17,7 +17,6 @@
     "dev:server": "tsx watch --ignore /**/node_modules/** --clear-screen=false --env-file-if-exists=.env --env-file-if-exists=.env.local --import ./src/instrument.ts src/index.ts | pino-pretty -t",
     "dev:workers": "tsx watch --ignore /**/node_modules/** --clear-screen=false --env-file-if-exists=.env --env-file-if-exists=.env.local --import ./src/instrument.ts src/scripts/run-workers.ts | pino-pretty -t",
     "generate:schema": "tsx --env-file-if-exists=.env --env-file-if-exists=.env.local src/index.ts --exit-after-generate-schema",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/todo-with-better-auth/apps/backend/package.json
+++ b/examples/todo-with-better-auth/apps/backend/package.json
@@ -17,7 +17,6 @@
     "dev:server": "tsx watch --ignore /**/node_modules/** --clear-screen=false --env-file-if-exists=.env --env-file-if-exists=.env.local --import ./src/instrument.ts src/index.ts | pino-pretty -t",
     "dev:workers": "tsx watch --ignore /**/node_modules/** --clear-screen=false --env-file-if-exists=.env --env-file-if-exists=.env.local --import ./src/instrument.ts src/scripts/run-workers.ts | pino-pretty -t",
     "generate:schema": "tsx --env-file-if-exists=.env --env-file-if-exists=.env.local src/index.ts --exit-after-generate-schema",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/todo-with-better-auth/apps/web/baseplate/generated/package.json
+++ b/examples/todo-with-better-auth/apps/web/baseplate/generated/package.json
@@ -13,7 +13,6 @@
     "dev": "vite",
     "gql:generate": "graphql-codegen",
     "gql:watch": "graphql-codegen --watch",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/todo-with-better-auth/apps/web/package.json
+++ b/examples/todo-with-better-auth/apps/web/package.json
@@ -13,7 +13,6 @@
     "dev": "vite",
     "gql:generate": "graphql-codegen",
     "gql:watch": "graphql-codegen --watch",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/todo-with-better-auth/baseplate/generated/package.json
+++ b/examples/todo-with-better-auth/baseplate/generated/package.json
@@ -12,7 +12,6 @@
     "build:affected": "turbo run build --affected",
     "check": "turbo run lint prettier:check test typecheck --affected --continue",
     "dev": "turbo run dev gql:watch watch",
-    "preinstall": "npx only-allow pnpm",
     "lint": "turbo run lint",
     "lint:affected": "turbo run lint --affected",
     "prettier:check": "turbo run prettier:check && pnpm run prettier:check:root",

--- a/examples/todo-with-better-auth/libs/transactional/baseplate/generated/package.json
+++ b/examples/todo-with-better-auth/libs/transactional/baseplate/generated/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/todo-with-better-auth/libs/transactional/package.json
+++ b/examples/todo-with-better-auth/libs/transactional/package.json
@@ -19,7 +19,6 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "preinstall": "npx only-allow pnpm",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:check": "prettier --check .",

--- a/examples/todo-with-better-auth/package.json
+++ b/examples/todo-with-better-auth/package.json
@@ -12,7 +12,6 @@
     "build:affected": "turbo run build --affected",
     "check": "turbo run lint prettier:check test typecheck --affected --continue",
     "dev": "turbo run dev gql:watch watch",
-    "preinstall": "npx only-allow pnpm",
     "lint": "turbo run lint",
     "lint:affected": "turbo run lint --affected",
     "prettier:check": "turbo run prettier:check && pnpm run prettier:check:root",

--- a/knip.config.js
+++ b/knip.config.js
@@ -157,7 +157,6 @@ export default {
     '**/string-merge-algorithms/tests/**',
     '**/generated/**',
   ],
-  ignoreBinaries: ['only-allow'],
   ignoreDependencies: [
     // we're not using vitest coverage
     '@vitest/coverage-v8',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "check:full": "pnpm oxfmt:fix && turbo run lint prettier:write typecheck test --affected --continue --output-logs=errors-only && pnpm run check:common && pnpm turbo run packages:dedupe",
     "clean": "turbo run clean",
     "dev:serve": "pnpm --color --reporter-hide-prefix --filter @baseplate-dev/project-builder-dev --filter @baseplate-dev/project-builder-web --parallel \"/dev:(serve|dev-server)/\"",
-    "preinstall": "npx only-allow pnpm",
     "knip": "knip",
     "lint": "turbo run lint --continue",
     "lint:affected": "turbo run lint --affected --continue",

--- a/packages/core-generators/src/generators/node/node/node.generator.ts
+++ b/packages/core-generators/src/generators/node/node/node.generator.ts
@@ -54,9 +54,7 @@ const nodePackageJsonFieldsSchema = createFieldMapSchemaBuilder((t) => ({
   /**
    * The scripts for the project
    */
-  scripts: t.mapFromObj<string>({
-    preinstall: 'npx only-allow pnpm',
-  }),
+  scripts: t.mapFromObj<string>({}),
   /**
    * The files that the package.json will have
    */

--- a/packages/core-generators/src/generators/node/node/node.generator.unit.test.ts
+++ b/packages/core-generators/src/generators/node/node/node.generator.unit.test.ts
@@ -50,9 +50,7 @@ describe('nodeGenerator', () => {
           node: `^${NODE_VERSION}`,
           pnpm: `^${PNPM_VERSION.split('.').slice(0, 2).join('.')}.0`,
         },
-        scripts: {
-          preinstall: 'npx only-allow pnpm',
-        },
+        scripts: {},
       });
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated projects no longer include a preinstall hook that restricts installations to pnpm.
  * Package-manager selection now follows the project’s declared package-manager configuration.

* **Bug Fixes**
  * Updated example projects to remove unnecessary pnpm-only installation enforcement.

* **Tests**
  * Updated generation checks to reflect the new default package script configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->