### PR TITLE
feat: Added opt-in Relay-style cursor pagination for list queries

### DIFF
--- a/.changeset/eng-921-connection-pagination.md
+++ b/.changeset/eng-921-connection-pagination.md
@@ -1,0 +1,8 @@
+---
+'@baseplate-dev/fastify-generators': patch
+'@baseplate-dev/project-builder-lib': patch
+'@baseplate-dev/project-builder-server': patch
+'@baseplate-dev/project-builder-web': patch
+---
+
+Added opt-in Relay-style cursor pagination for list queries. Enable "Connection" alongside a model's existing "List" query in the GraphQL section of the model editor to generate a `<model>sConnection(first, after, last, before)` query backed by Pothos's `t.prismaConnection`, returning a `<Model>Connection` type with `edges`, `pageInfo`, and `totalCount`.

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/todos/schema/todo-list-share.queries.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/todos/schema/todo-list-share.queries.ts
@@ -36,3 +36,17 @@ builder.queryField('todoListShares', (t) =>
       }),
   }),
 );
+
+builder.queryField('todoListSharesConnection', (t) =>
+  t.prismaConnection(
+    {
+      type: 'TodoListShare',
+      cursor: 'todoListId_userId',
+      authorize: ['user'],
+      totalCount: () => prisma.todoListShare.count(),
+      resolve: async (query) => prisma.todoListShare.findMany({ ...query }),
+    },
+    { name: 'TodoListShareConnection' },
+    { name: 'TodoListShareEdge' },
+  ),
+);

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/todos/schema/todo-list.queries.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/todos/schema/todo-list.queries.ts
@@ -38,3 +38,22 @@ builder.queryField('todoLists', (t) =>
       }),
   }),
 );
+
+builder.queryField('todoListsConnection', (t) =>
+  t.prismaConnection(
+    {
+      type: 'TodoList',
+      cursor: 'id',
+      authorize: ['admin'],
+      totalCount: (_connection, _args, ctx) =>
+        prisma.todoList.count({ where: todoListPolicy.read.where(ctx) }),
+      resolve: async (query, _root, _args, ctx) =>
+        prisma.todoList.findMany({
+          ...query,
+          where: todoListPolicy.read.where(ctx),
+        }),
+    },
+    { name: 'TodoListConnection' },
+    { name: 'TodoListEdge' },
+  ),
+);

--- a/examples/todo-with-better-auth/apps/backend/src/modules/todos/schema/connection-query.e2e.test.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/todos/schema/connection-query.e2e.test.ts
@@ -1,0 +1,234 @@
+import type { FastifyInstance } from 'fastify';
+
+import Fastify from 'fastify';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { AuthRole } from '@src/modules/accounts/auth/constants/auth-roles.constants.js';
+
+import { createAuthContextFromSessionInfo } from '@src/modules/accounts/auth/utils/auth-context.utils.js';
+import { graphqlPlugin } from '@src/plugins/graphql/index.js';
+import { prisma } from '@src/services/prisma.js';
+import { createServiceContext } from '@src/utils/service-context.js';
+
+async function buildApp(
+  roles: AuthRole[],
+  userId?: string,
+): Promise<FastifyInstance> {
+  const fastify = Fastify();
+  fastify.decorateRequest('serviceContext');
+  fastify.addHook('preHandler', (req, _reply, done) => {
+    req.serviceContext = {
+      ...createServiceContext(
+        {
+          auth: createAuthContextFromSessionInfo(
+            userId === undefined
+              ? undefined
+              : { type: 'user', id: 'test-session', userId, roles },
+          ),
+        },
+        {},
+      ),
+      cookieStore: {
+        get: () => undefined,
+        set: () => undefined,
+        clear: () => undefined,
+      },
+      reqInfo: {
+        id: 'test',
+        url: '/graphql',
+        method: 'POST',
+        headers: {},
+        ip: '127.0.0.1',
+      },
+    };
+    done();
+  });
+  await fastify.register(graphqlPlugin);
+  return fastify;
+}
+
+async function queryGraphql(
+  fastify: FastifyInstance,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<{ data?: Record<string, unknown>; errors?: { message: string }[] }> {
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/graphql',
+    payload: { query, variables },
+  });
+  return JSON.parse(response.body) as {
+    data?: Record<string, unknown>;
+    errors?: { message: string }[];
+  };
+}
+
+beforeEach(async () => {
+  await prisma.todoListShare.deleteMany({});
+  await prisma.todoList.deleteMany({});
+  await prisma.user.deleteMany({});
+});
+
+describe('todoListsConnection', () => {
+  it('paginates with a cursor and reports totalCount for a single-column primary key', async () => {
+    const owner = await prisma.user.create({
+      data: { name: 'Owner', email: 'owner@example.com' },
+    });
+
+    const lists = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        prisma.todoList.create({
+          data: { ownerId: owner.id, position: i, name: `List ${i}` },
+        }),
+      ),
+    );
+
+    const fastify = await buildApp(['public', 'user', 'admin'], owner.id);
+
+    const firstPage = await queryGraphql(
+      fastify,
+      `query ($first: Int, $after: String) {
+        todoListsConnection(first: $first, after: $after) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          edges { cursor node { id name } }
+        }
+      }`,
+      { first: 2 },
+    );
+
+    expect(firstPage.errors).toBeUndefined();
+    const firstConnection = firstPage.data?.todoListsConnection as {
+      totalCount: number;
+      pageInfo: { hasNextPage: boolean; endCursor: string };
+      edges: { cursor: string; node: { id: string; name: string } }[];
+    };
+
+    expect(firstConnection.totalCount).toBe(5);
+    expect(firstConnection.edges).toHaveLength(2);
+    expect(firstConnection.pageInfo.hasNextPage).toBe(true);
+
+    const secondPage = await queryGraphql(
+      fastify,
+      `query ($first: Int, $after: String) {
+        todoListsConnection(first: $first, after: $after) {
+          pageInfo { hasNextPage endCursor }
+          edges { node { id } }
+        }
+      }`,
+      { first: 2, after: firstConnection.pageInfo.endCursor },
+    );
+
+    expect(secondPage.errors).toBeUndefined();
+    const secondConnection = secondPage.data?.todoListsConnection as {
+      pageInfo: { hasNextPage: boolean; endCursor: string };
+      edges: { node: { id: string } }[];
+    };
+    expect(secondConnection.edges).toHaveLength(2);
+    expect(secondConnection.pageInfo.hasNextPage).toBe(true);
+
+    const thirdPage = await queryGraphql(
+      fastify,
+      `query ($first: Int, $after: String) {
+        todoListsConnection(first: $first, after: $after) {
+          pageInfo { hasNextPage }
+          edges { node { id } }
+        }
+      }`,
+      { first: 2, after: secondConnection.pageInfo.endCursor },
+    );
+
+    expect(thirdPage.errors).toBeUndefined();
+    const thirdConnection = thirdPage.data?.todoListsConnection as {
+      pageInfo: { hasNextPage: boolean };
+      edges: { node: { id: string } }[];
+    };
+    expect(thirdConnection.edges).toHaveLength(1);
+    expect(thirdConnection.pageInfo.hasNextPage).toBe(false);
+
+    // Pages partition the full set with no overlap or gaps, regardless of order.
+    const seenIds = [
+      ...firstConnection.edges.map((e) => e.node.id),
+      ...secondConnection.edges.map((e) => e.node.id),
+      ...thirdConnection.edges.map((e) => e.node.id),
+    ];
+    expect(new Set(seenIds).size).toBe(5);
+    expect(seenIds.toSorted()).toEqual(lists.map((l) => l.id).toSorted());
+
+    await fastify.close();
+  });
+
+  it('rejects non-admin access', async () => {
+    const owner = await prisma.user.create({
+      data: { name: 'Owner', email: 'owner2@example.com' },
+    });
+    const fastify = await buildApp(['public', 'user'], owner.id);
+
+    const result = await queryGraphql(
+      fastify,
+      `query { todoListsConnection(first: 1) { totalCount } }`,
+    );
+
+    expect(result.errors).toBeDefined();
+    await fastify.close();
+  });
+});
+
+describe('todoListSharesConnection', () => {
+  it('paginates using the composite primary key as the cursor', async () => {
+    const owner = await prisma.user.create({
+      data: { name: 'Owner', email: 'owner3@example.com' },
+    });
+    const otherUsers = await Promise.all(
+      Array.from({ length: 3 }, (_, i) =>
+        prisma.user.create({
+          data: { name: `Sharee ${i}`, email: `sharee${i}@example.com` },
+        }),
+      ),
+    );
+    const list = await prisma.todoList.create({
+      data: { ownerId: owner.id, position: 0, name: 'Shared List' },
+    });
+
+    await Promise.all(
+      otherUsers.map((u) =>
+        prisma.todoListShare.create({
+          data: { todoListId: list.id, userId: u.id },
+        }),
+      ),
+    );
+
+    const fastify = await buildApp(['public', 'user'], owner.id);
+
+    const result = await queryGraphql(
+      fastify,
+      `query ($first: Int) {
+        todoListSharesConnection(first: $first) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          edges { cursor node { todoListId userId } }
+        }
+      }`,
+      { first: 2 },
+    );
+
+    expect(result.errors).toBeUndefined();
+    const connection = result.data?.todoListSharesConnection as {
+      totalCount: number;
+      pageInfo: { hasNextPage: boolean; endCursor: string };
+      edges: { cursor: string; node: { todoListId: string; userId: string } }[];
+    };
+
+    expect(connection.totalCount).toBe(3);
+    expect(connection.edges).toHaveLength(2);
+    expect(connection.pageInfo.hasNextPage).toBe(true);
+    // cursor is opaque base64, but must decode to the compound key
+    const decoded = Buffer.from(
+      connection.edges[0]?.cursor ?? '',
+      'base64',
+    ).toString('utf8');
+    expect(decoded).toContain(list.id);
+
+    await fastify.close();
+  });
+});

--- a/examples/todo-with-better-auth/apps/backend/src/modules/todos/schema/todo-list-share.queries.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/todos/schema/todo-list-share.queries.ts
@@ -36,3 +36,17 @@ builder.queryField('todoListShares', (t) =>
       }),
   }),
 );
+
+builder.queryField('todoListSharesConnection', (t) =>
+  t.prismaConnection(
+    {
+      type: 'TodoListShare',
+      cursor: 'todoListId_userId',
+      authorize: ['user'],
+      totalCount: () => prisma.todoListShare.count(),
+      resolve: async (query) => prisma.todoListShare.findMany({ ...query }),
+    },
+    { name: 'TodoListShareConnection' },
+    { name: 'TodoListShareEdge' },
+  ),
+);

--- a/examples/todo-with-better-auth/apps/backend/src/modules/todos/schema/todo-list.queries.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/todos/schema/todo-list.queries.ts
@@ -38,3 +38,22 @@ builder.queryField('todoLists', (t) =>
       }),
   }),
 );
+
+builder.queryField('todoListsConnection', (t) =>
+  t.prismaConnection(
+    {
+      type: 'TodoList',
+      cursor: 'id',
+      authorize: ['admin'],
+      totalCount: (_connection, _args, ctx) =>
+        prisma.todoList.count({ where: todoListPolicy.read.where(ctx) }),
+      resolve: async (query, _root, _args, ctx) =>
+        prisma.todoList.findMany({
+          ...query,
+          where: todoListPolicy.read.where(ctx),
+        }),
+    },
+    { name: 'TodoListConnection' },
+    { name: 'TodoListEdge' },
+  ),
+);

--- a/examples/todo-with-better-auth/baseplate/project-definition.json
+++ b/examples/todo-with-better-auth/baseplate/project-definition.json
@@ -1158,7 +1158,7 @@
           "get": { "enabled": true },
           "globalRoles": ["admin"],
           "instanceRoles": ["owner"],
-          "list": { "enabled": true }
+          "list": { "connection": { "enabled": true }, "enabled": true }
         }
       },
       "id": "model:ONd_Fbo61Tx7",
@@ -1300,7 +1300,7 @@
         "queries": {
           "get": { "enabled": true },
           "globalRoles": ["user"],
-          "list": { "enabled": true }
+          "list": { "connection": { "enabled": true }, "enabled": true }
         }
       },
       "id": "model:nmsOHh3rZMmE",

--- a/examples/todo-with-better-auth/baseplate/snapshots/backend/manifest.json
+++ b/examples/todo-with-better-auth/baseplate/snapshots/backend/manifest.json
@@ -11,6 +11,7 @@
       {
         "path": "src/modules/todos/authorizers/todo-item.query-filter.int.test.ts"
       },
+      { "path": "src/modules/todos/schema/connection-query.e2e.test.ts" },
       { "path": "src/modules/todos/services/todo-item-service.int.test.ts" },
       { "path": "src/plugins/stripe-webhook.int.test.ts" },
       { "path": "src/services/bullmq.service.int.test.ts" },

--- a/packages/fastify-generators/src/generators/pothos/index.ts
+++ b/packages/fastify-generators/src/generators/pothos/index.ts
@@ -2,6 +2,7 @@ export * from './_providers/index.js';
 export * from './pothos-auth/index.js';
 export * from './pothos-authorize-field/index.js';
 export * from './pothos-enums-file/index.js';
+export * from './pothos-prisma-connection-query/index.js';
 export * from './pothos-prisma-count-query/index.js';
 export * from './pothos-prisma-crud-mutation/index.js';
 export * from './pothos-prisma-enum/index.js';

--- a/packages/fastify-generators/src/generators/pothos/pothos-prisma-connection-query/index.ts
+++ b/packages/fastify-generators/src/generators/pothos/pothos-prisma-connection-query/index.ts
@@ -1,0 +1,1 @@
+export * from './pothos-prisma-connection-query.generator.js';

--- a/packages/fastify-generators/src/generators/pothos/pothos-prisma-connection-query/pothos-prisma-connection-query.generator.ts
+++ b/packages/fastify-generators/src/generators/pothos/pothos-prisma-connection-query/pothos-prisma-connection-query.generator.ts
@@ -1,0 +1,118 @@
+import type { TsCodeFragment } from '@baseplate-dev/core-generators';
+
+import { TsCodeUtils, tsTemplate } from '@baseplate-dev/core-generators';
+import {
+  createGenerator,
+  createGeneratorTask,
+  createNonOverwriteableMap,
+} from '@baseplate-dev/sync';
+import { quot, sortObjectKeys, uppercaseFirstChar } from '@baseplate-dev/utils';
+import { pluralize } from 'inflection';
+import { z } from 'zod';
+
+import { pothosFieldProvider } from '#src/generators/pothos/_providers/pothos-field.js';
+import { getModelIdFieldName } from '#src/generators/prisma/_shared/crud-method/primary-key-input.js';
+import { prismaModelPolicyProvider } from '#src/generators/prisma/prisma-model-authorizer/index.js';
+import { prismaOutputProvider } from '#src/generators/prisma/prisma/index.js';
+import { lowerCaseFirst } from '#src/utils/case.js';
+
+import { pothosFieldScope } from '../_providers/scopes.js';
+import { pothosTypesFileProvider } from '../pothos-types-file/index.js';
+
+const descriptorSchema = z.object({
+  /**
+   * The name of the model.
+   */
+  modelName: z.string().min(1),
+  /**
+   * The order of the type in the types file.
+   */
+  order: z.number(),
+  /**
+   * Model name key to look up the model policy provider. When set, the resolve
+   * and totalCount functions filter with `policy.read.where(ctx)`.
+   */
+  policyRef: z.string().optional(),
+});
+
+export const pothosPrismaConnectionQueryGenerator = createGenerator({
+  name: 'pothos/pothos-prisma-connection-query',
+  generatorFileUrl: import.meta.url,
+  descriptorSchema,
+  scopes: [pothosFieldScope],
+  buildTasks: ({ modelName, order, policyRef }) => ({
+    main: createGeneratorTask({
+      dependencies: {
+        prismaOutput: prismaOutputProvider,
+        pothosTypesFile: pothosTypesFileProvider,
+        modelPolicy: prismaModelPolicyProvider
+          .dependency()
+          .optionalReference(policyRef),
+      },
+      exports: {
+        pothosField: pothosFieldProvider.export(pothosFieldScope),
+      },
+      run({ prismaOutput, pothosTypesFile, modelPolicy }) {
+        const modelOutput = prismaOutput.getPrismaModel(modelName);
+
+        const { idFields } = modelOutput;
+
+        if (!idFields) {
+          throw new Error(`Model ${modelName} does not have an ID field`);
+        }
+
+        const queryName = `${pluralize(lowerCaseFirst(modelName))}Connection`;
+        const cursorFieldName = getModelIdFieldName(modelOutput);
+
+        const customFields = createNonOverwriteableMap<
+          Record<string, TsCodeFragment>
+        >({});
+
+        return {
+          providers: {
+            pothosField: {
+              addCustomOption(field) {
+                customFields.set(field.name, field.value);
+              },
+            },
+          },
+          build: () => {
+            const prismaModelFragment =
+              prismaOutput.getPrismaModelFragment(modelName);
+
+            const resolveFunction: TsCodeFragment = modelPolicy
+              ? tsTemplate`async (query, _root, _args, ctx) => ${prismaModelFragment}.findMany({ ...query, where: ${modelPolicy.getActionWhereFragment('read')}(ctx) })`
+              : tsTemplate`async (query) => ${prismaModelFragment}.findMany({ ...query })`;
+
+            const totalCountFunction: TsCodeFragment = modelPolicy
+              ? tsTemplate`(_connection, _args, ctx) => ${prismaModelFragment}.count({ where: ${modelPolicy.getActionWhereFragment('read')}(ctx) })`
+              : tsTemplate`() => ${prismaModelFragment}.count()`;
+
+            const options = {
+              type: quot(modelName),
+              cursor: quot(cursorFieldName),
+              ...sortObjectKeys(customFields.value()),
+              totalCount: totalCountFunction,
+              resolve: resolveFunction,
+            };
+
+            const block = tsTemplate`${pothosTypesFile.getBuilderFragment()}.queryField(
+              ${quot(queryName)},
+              (t) => t.prismaConnection(
+                ${TsCodeUtils.mergeFragmentsAsObject(options, { disableSort: true })},
+                { name: ${quot(`${uppercaseFirstChar(modelName)}Connection`)} },
+                { name: ${quot(`${uppercaseFirstChar(modelName)}Edge`)} },
+              )
+            )`;
+
+            pothosTypesFile.typeDefinitions.add({
+              name: `${queryName}Query`,
+              fragment: block,
+              order,
+            });
+          },
+        };
+      },
+    }),
+  }),
+});

--- a/packages/project-builder-lib/src/schema/models/graphql.ts
+++ b/packages/project-builder-lib/src/schema/models/graphql.ts
@@ -139,6 +139,12 @@ export const createModelGraphqlSchema = definitionSchemaWithSlots(
                 }),
                 {},
               ),
+              connection: ctx.withDefault(
+                z.object({
+                  enabled: ctx.withDefault(z.boolean(), false),
+                }),
+                {},
+              ),
             }),
             {},
           ),

--- a/packages/project-builder-server/src/compiler/backend/graphql.ts
+++ b/packages/project-builder-server/src/compiler/backend/graphql.ts
@@ -7,6 +7,7 @@ import type { GeneratorBundle } from '@baseplate-dev/sync';
 import {
   pothosAuthorizeFieldGenerator,
   pothosEnumsFileGenerator,
+  pothosPrismaConnectionQueryGenerator,
   pothosPrismaCountQueryGenerator,
   pothosPrismaCrudMutationGenerator,
   pothosPrismaEnumGenerator,
@@ -159,6 +160,17 @@ function buildQueriesFileForModel(
         list.enabled && list.count.enabled
           ? pothosPrismaCountQueryGenerator({
               order: 2,
+              modelName: model.name,
+              policyRef,
+              children: {
+                authorize,
+              },
+            })
+          : undefined,
+      connectionQuery:
+        list.enabled && list.connection.enabled
+          ? pothosPrismaConnectionQueryGenerator({
+              order: 3,
               modelName: model.name,
               policyRef,
               children: {

--- a/packages/project-builder-web/src/routes/data/models/edit.$key/-components/graphql/graph-ql-root-fields-section.tsx
+++ b/packages/project-builder-web/src/routes/data/models/edit.$key/-components/graphql/graph-ql-root-fields-section.tsx
@@ -84,6 +84,13 @@ export function GraphQLRootFieldsSection({
               label="Count"
               description="Count matching records, e.g. postsCount(...)"
             />
+            <ToggleItem
+              control={control}
+              name="graphql.queries.list.connection.enabled"
+              disabled={!isObjectTypeEnabled}
+              label="Connection"
+              description="Cursor-based pagination, e.g. postsConnection(first, after)"
+            />
           </div>
           {hasAnyMutation && (
             <div className="space-y-4">
@@ -135,6 +142,7 @@ function ToggleItem({
     | 'graphql.queries.get.enabled'
     | 'graphql.queries.list.enabled'
     | 'graphql.queries.list.count.enabled'
+    | 'graphql.queries.list.connection.enabled'
     | 'graphql.mutations.create.enabled'
     | 'graphql.mutations.update.enabled'
     | 'graphql.mutations.delete.enabled';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in Connection setting for GraphQL list queries in the model editor.
  - Enabled cursor-based pagination with `first`, `after`, `last`, and `before` arguments.
  - Connection results include edges, page information, and total counts.
  - Added pagination support for todo lists and todo list shares, including composite-key cursors.

- **Bug Fixes**
  - Added coverage confirming pagination boundaries, access controls, cursors, and record counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->