### PR TITLE
feat: Added opt-in `skip`/`take` pagination args to to-many relation fields

### DIFF
--- a/.changeset/eng-924-relation-pagination.md
+++ b/.changeset/eng-924-relation-pagination.md
@@ -1,0 +1,8 @@
+---
+'@baseplate-dev/fastify-generators': patch
+'@baseplate-dev/project-builder-lib': patch
+'@baseplate-dev/project-builder-server': patch
+'@baseplate-dev/project-builder-web': patch
+---
+
+Added opt-in `skip`/`take` pagination args to to-many relation fields on object types (e.g. `user.todoLists(skip, take)`), mirroring the existing pagination on root list queries. Enable it via a new toggle next to each exposed foreign relation in the GraphQL section of the model editor.

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/accounts/users/schema/user.object-type.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/accounts/users/schema/user.object-type.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import { builder } from '@src/plugins/graphql/builder.js';
 
 import { userPolicy } from '../authorizers/user.policy.js';
@@ -13,7 +15,16 @@ export const userObjectType = builder.prismaObject('User', {
     createdAt: t.expose('createdAt', { type: 'DateTime' }),
     customer: t.relation('customer', { nullable: true }),
     roles: t.relation('roles'),
-    todoLists: t.relation('todoLists'),
+    todoLists: t.relation('todoLists', {
+      args: {
+        skip: t.arg.int({ validate: z.int().min(0) }),
+        take: t.arg.int({ validate: z.int().min(0) }),
+      },
+      query: (args) => ({
+        skip: args.skip ?? undefined,
+        take: args.take ?? undefined,
+      }),
+    }),
     userProfile: t.relation('userProfile', { nullable: true }),
   }),
 });

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/accounts/users/schema/user.object-type.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/accounts/users/schema/user.object-type.ts
@@ -23,6 +23,7 @@ export const userObjectType = builder.prismaObject('User', {
       query: (args) => ({
         skip: args.skip ?? undefined,
         take: args.take ?? undefined,
+        orderBy: { id: 'asc' },
       }),
     }),
     userProfile: t.relation('userProfile', { nullable: true }),

--- a/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/relation-pagination.e2e.test.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/relation-pagination.e2e.test.ts
@@ -1,0 +1,164 @@
+import type { FastifyInstance } from 'fastify';
+
+import Fastify from 'fastify';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { AuthRole } from '@src/modules/accounts/auth/constants/auth-roles.constants.js';
+
+import { createAuthContextFromSessionInfo } from '@src/modules/accounts/auth/utils/auth-context.utils.js';
+import { graphqlPlugin } from '@src/plugins/graphql/index.js';
+import { prisma } from '@src/services/prisma.js';
+import { createServiceContext } from '@src/utils/service-context.js';
+
+async function buildApp(
+  roles: AuthRole[],
+  userId?: string,
+): Promise<FastifyInstance> {
+  const fastify = Fastify();
+  fastify.decorateRequest('serviceContext');
+  fastify.addHook('preHandler', (req, _reply, done) => {
+    req.serviceContext = {
+      ...createServiceContext(
+        {
+          auth: createAuthContextFromSessionInfo(
+            userId === undefined
+              ? undefined
+              : { type: 'user', id: 'test-session', userId, roles },
+          ),
+        },
+        {},
+      ),
+      cookieStore: {
+        get: () => undefined,
+        set: () => undefined,
+        clear: () => undefined,
+      },
+      reqInfo: {
+        id: 'test',
+        url: '/graphql',
+        method: 'POST',
+        headers: {},
+        ip: '127.0.0.1',
+      },
+    };
+    done();
+  });
+  await fastify.register(graphqlPlugin);
+  return fastify;
+}
+
+async function queryGraphql(
+  fastify: FastifyInstance,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<{ data?: Record<string, unknown>; errors?: { message: string }[] }> {
+  const response = await fastify.inject({
+    method: 'POST',
+    url: '/graphql',
+    payload: { query, variables },
+  });
+  return JSON.parse(response.body) as {
+    data?: Record<string, unknown>;
+    errors?: { message: string }[];
+  };
+}
+
+beforeEach(async () => {
+  await prisma.todoListShare.deleteMany({});
+  await prisma.todoList.deleteMany({});
+  await prisma.user.deleteMany({});
+});
+
+describe('User.todoLists', () => {
+  it('returns all related records when no pagination args are given', async () => {
+    const owner = await prisma.user.create({
+      data: { name: 'Owner', email: 'owner@example.com' },
+    });
+    await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        prisma.todoList.create({
+          data: { ownerId: owner.id, position: i, name: `List ${i}` },
+        }),
+      ),
+    );
+
+    const fastify = await buildApp(['public', 'user'], owner.id);
+
+    const result = await queryGraphql(
+      fastify,
+      `query ($id: Uuid!) {
+        user(id: $id) {
+          todoLists { id }
+        }
+      }`,
+      { id: owner.id },
+    );
+
+    expect(result.errors).toBeUndefined();
+    const user = result.data?.user as { todoLists: { id: string }[] };
+    expect(user.todoLists).toHaveLength(5);
+
+    await fastify.close();
+  });
+
+  it('applies skip and take to truncate and offset the result', async () => {
+    const owner = await prisma.user.create({
+      data: { name: 'Owner', email: 'owner2@example.com' },
+    });
+    const lists = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        prisma.todoList.create({
+          data: { ownerId: owner.id, position: i, name: `List ${i}` },
+        }),
+      ),
+    );
+
+    const fastify = await buildApp(['public', 'user'], owner.id);
+
+    const result = await queryGraphql(
+      fastify,
+      `query ($id: Uuid!, $skip: Int, $take: Int) {
+        user(id: $id) {
+          todoLists(skip: $skip, take: $take) { id }
+        }
+      }`,
+      { id: owner.id, skip: 2, take: 2 },
+    );
+
+    expect(result.errors).toBeUndefined();
+    const user = result.data?.user as { todoLists: { id: string }[] };
+    expect(user.todoLists).toHaveLength(2);
+    expect(user.todoLists.map((t) => t.id)).toEqual(
+      lists.slice(2, 4).map((l) => l.id),
+    );
+
+    await fastify.close();
+  });
+
+  it('returns an empty array when skip exceeds the available count', async () => {
+    const owner = await prisma.user.create({
+      data: { name: 'Owner', email: 'owner3@example.com' },
+    });
+    await prisma.todoList.create({
+      data: { ownerId: owner.id, position: 0, name: 'Only List' },
+    });
+
+    const fastify = await buildApp(['public', 'user'], owner.id);
+
+    const result = await queryGraphql(
+      fastify,
+      `query ($id: Uuid!, $skip: Int) {
+        user(id: $id) {
+          todoLists(skip: $skip) { id }
+        }
+      }`,
+      { id: owner.id, skip: 10 },
+    );
+
+    expect(result.errors).toBeUndefined();
+    const user = result.data?.user as { todoLists: { id: string }[] };
+    expect(user.todoLists).toHaveLength(0);
+
+    await fastify.close();
+  });
+});

--- a/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/relation-pagination.e2e.test.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/relation-pagination.e2e.test.ts
@@ -105,10 +105,17 @@ describe('User.todoLists', () => {
     const owner = await prisma.user.create({
       data: { name: 'Owner', email: 'owner2@example.com' },
     });
+    // Assign explicit, lexically-sortable ids so ordering (by id) is
+    // deterministic regardless of creation order or timing.
     const lists = await Promise.all(
       Array.from({ length: 5 }, (_, i) =>
         prisma.todoList.create({
-          data: { ownerId: owner.id, position: i, name: `List ${i}` },
+          data: {
+            id: `00000000-0000-0000-0000-00000000000${i}`,
+            ownerId: owner.id,
+            position: i,
+            name: `List ${i}`,
+          },
         }),
       ),
     );

--- a/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/user.object-type.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/user.object-type.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import { builder } from '@src/plugins/graphql/builder.js';
 
 import { userPolicy } from '../authorizers/user.policy.js';
@@ -13,7 +15,16 @@ export const userObjectType = builder.prismaObject('User', {
     createdAt: t.expose('createdAt', { type: 'DateTime' }),
     customer: t.relation('customer', { nullable: true }),
     roles: t.relation('roles'),
-    todoLists: t.relation('todoLists'),
+    todoLists: t.relation('todoLists', {
+      args: {
+        skip: t.arg.int({ validate: z.int().min(0) }),
+        take: t.arg.int({ validate: z.int().min(0) }),
+      },
+      query: (args) => ({
+        skip: args.skip ?? undefined,
+        take: args.take ?? undefined,
+      }),
+    }),
     userProfile: t.relation('userProfile', { nullable: true }),
   }),
 });

--- a/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/user.object-type.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/user.object-type.ts
@@ -23,6 +23,7 @@ export const userObjectType = builder.prismaObject('User', {
       query: (args) => ({
         skip: args.skip ?? undefined,
         take: args.take ?? undefined,
+        orderBy: { id: 'asc' },
       }),
     }),
     userProfile: t.relation('userProfile', { nullable: true }),

--- a/examples/todo-with-better-auth/baseplate/project-definition.json
+++ b/examples/todo-with-better-auth/baseplate/project-definition.json
@@ -1409,7 +1409,7 @@
           ],
           "foreignRelations": [
             { "ref": "roles" },
-            { "ref": "todoLists" },
+            { "ref": "todoLists", "paginated": true },
             { "ref": "userProfile" },
             { "ref": "customer" }
           ]

--- a/examples/todo-with-better-auth/baseplate/snapshots/backend/manifest.json
+++ b/examples/todo-with-better-auth/baseplate/snapshots/backend/manifest.json
@@ -1,6 +1,9 @@
 {
   "files": {
     "added": [
+      {
+        "path": "src/modules/accounts/users/schema/relation-pagination.e2e.test.ts"
+      },
       { "path": "src/modules/accounts/users/services/user.crud.int.test.ts" },
       {
         "path": "src/modules/accounts/users/services/user.data-service.int.test.ts"

--- a/packages/fastify-generators/src/generators/pothos/pothos-prisma-object/pothos-prisma-object.generator.ts
+++ b/packages/fastify-generators/src/generators/pothos/pothos-prisma-object/pothos-prisma-object.generator.ts
@@ -35,6 +35,7 @@ const exposedFieldSchema = z.object({
   name: z.string().min(1),
   globalRoles: z.array(z.string().min(1)).default([]),
   instanceRoles: z.array(z.string().min(1)).default([]),
+  paginated: z.boolean().default(false),
 });
 
 const descriptorSchema = z.object({
@@ -115,6 +116,13 @@ export const pothosPrismaObjectGenerator = createGenerator({
             ]),
         );
 
+        // Build lookup: fieldName → paginated flag
+        const fieldPaginatedMap = new Map(
+          exposedFields
+            .filter((f) => f.paginated)
+            .map((f) => [f.name, f.paginated]),
+        );
+
         /**
          * Build an authorize TsCodeFragment for a field, if it has auth config.
          */
@@ -186,10 +194,19 @@ export const pothosPrismaObjectGenerator = createGenerator({
               );
             }
 
+            const zFragment = TsCodeUtils.importFragment('z', 'zod');
+
             const fieldDefinitions = outputDto.fields
               .filter((field) => exposedFieldNames.includes(field.name))
               .map((field) => {
                 const authorize = buildAuthorizeFragment(field.name);
+                const paginated = fieldPaginatedMap.get(field.name) ?? false;
+
+                if (paginated && !field.isList) {
+                  throw new Error(
+                    `Field '${field.name}' on model '${modelName}' is marked paginated but is not a list relation.`,
+                  );
+                }
 
                 let fragment: string | TsCodeFragment;
                 if (field.type === 'scalar') {
@@ -200,14 +217,21 @@ export const pothosPrismaObjectGenerator = createGenerator({
                     typeReferences: [],
                     authorize,
                   });
-                } else if (authorize || field.isNullable) {
-                  // Relation with options (nullable and/or authorize)
+                } else if (authorize || field.isNullable || paginated) {
+                  // Relation with options (nullable, authorize, and/or pagination)
                   const options: Record<string, string | TsCodeFragment> = {};
                   if (field.isNullable) {
                     options.nullable = 'true';
                   }
                   if (authorize) {
                     options.authorize = authorize;
+                  }
+                  if (paginated) {
+                    options.args = tsTemplate`{
+                      skip: t.arg.int({ validate: ${zFragment}.int().min(0) }),
+                      take: t.arg.int({ validate: ${zFragment}.int().min(0) }),
+                    }`;
+                    options.query = tsTemplate`(args) => ({ skip: args.skip ?? undefined, take: args.take ?? undefined })`;
                   }
                   fragment = tsTemplate`t.relation(${quot(field.name)}, ${TsCodeUtils.mergeFragmentsAsObject(options)})`;
                 } else {

--- a/packages/fastify-generators/src/generators/pothos/pothos-prisma-object/pothos-prisma-object.generator.ts
+++ b/packages/fastify-generators/src/generators/pothos/pothos-prisma-object/pothos-prisma-object.generator.ts
@@ -14,6 +14,7 @@ import {
 import { quot } from '@baseplate-dev/utils';
 import { z } from 'zod';
 
+import { getModelIdFieldName } from '#src/generators/prisma/_shared/crud-method/primary-key-input.js';
 import { prismaModelPolicyProvider } from '#src/generators/prisma/prisma-model-authorizer/index.js';
 import { prismaOutputProvider } from '#src/generators/prisma/prisma/index.js';
 import { prismaToServiceOutputDto } from '#src/types/service-output.js';
@@ -227,11 +228,23 @@ export const pothosPrismaObjectGenerator = createGenerator({
                     options.authorize = authorize;
                   }
                   if (paginated) {
+                    const relatedModel = prismaOutput.getPrismaModel(
+                      field.nestedType.name,
+                    );
+                    const idFieldNames = relatedModel.idFields ?? [
+                      getModelIdFieldName(relatedModel),
+                    ];
+                    const orderByFragment = TsCodeUtils.mergeFragmentsAsObject(
+                      Object.fromEntries(
+                        idFieldNames.map((name) => [name, quot('asc')]),
+                      ),
+                    );
+
                     options.args = tsTemplate`{
                       skip: t.arg.int({ validate: ${zFragment}.int().min(0) }),
                       take: t.arg.int({ validate: ${zFragment}.int().min(0) }),
                     }`;
-                    options.query = tsTemplate`(args) => ({ skip: args.skip ?? undefined, take: args.take ?? undefined, orderBy: { id: 'asc' } })`;
+                    options.query = tsTemplate`(args) => ({ skip: args.skip ?? undefined, take: args.take ?? undefined, orderBy: ${orderByFragment} })`;
                   }
                   fragment = tsTemplate`t.relation(${quot(field.name)}, ${TsCodeUtils.mergeFragmentsAsObject(options)})`;
                 } else {

--- a/packages/fastify-generators/src/generators/pothos/pothos-prisma-object/pothos-prisma-object.generator.ts
+++ b/packages/fastify-generators/src/generators/pothos/pothos-prisma-object/pothos-prisma-object.generator.ts
@@ -231,7 +231,7 @@ export const pothosPrismaObjectGenerator = createGenerator({
                       skip: t.arg.int({ validate: ${zFragment}.int().min(0) }),
                       take: t.arg.int({ validate: ${zFragment}.int().min(0) }),
                     }`;
-                    options.query = tsTemplate`(args) => ({ skip: args.skip ?? undefined, take: args.take ?? undefined })`;
+                    options.query = tsTemplate`(args) => ({ skip: args.skip ?? undefined, take: args.take ?? undefined, orderBy: { id: 'asc' } })`;
                   }
                   fragment = tsTemplate`t.relation(${quot(field.name)}, ${TsCodeUtils.mergeFragmentsAsObject(options)})`;
                 } else {

--- a/packages/project-builder-lib/src/schema/models/graphql.ts
+++ b/packages/project-builder-lib/src/schema/models/graphql.ts
@@ -104,6 +104,7 @@ export const createModelGraphqlSchema = definitionSchemaWithSlots(
                   ),
                   [],
                 ),
+                paginated: ctx.withDefault(z.boolean(), false),
               }),
             )
             .apply(withByKeyMergeRule({ getKey: (item) => item.ref }))

--- a/packages/project-builder-server/src/compiler/backend/graphql.ts
+++ b/packages/project-builder-server/src/compiler/backend/graphql.ts
@@ -48,6 +48,20 @@ function buildObjectTypeFile(
     appBuilder.projectDefinition,
   );
 
+  const toExposedField = (entry: {
+    ref: string;
+    globalRoles: string[];
+    instanceRoles: string[];
+  }): { name: string; globalRoles: string[]; instanceRoles: string[] } => ({
+    name: appBuilder.nameFromId(entry.ref),
+    globalRoles: isAuthEnabled
+      ? entry.globalRoles.map((r) => appBuilder.nameFromId(r))
+      : [],
+    instanceRoles: isAuthEnabled
+      ? entry.instanceRoles.map((r) => appBuilder.nameFromId(r))
+      : [],
+  });
+
   return pothosTypesFileGenerator({
     id: `${model.id}-object-type`,
     fileName: `${kebabCase(model.name)}.object-type`,
@@ -62,17 +76,14 @@ function buildObjectTypeFile(
           : undefined,
       objectType: pothosPrismaObjectGenerator({
         modelName: model.name,
-        exposedFields: [...fields, ...foreignRelations, ...localRelations].map(
-          (entry) => ({
-            name: appBuilder.nameFromId(entry.ref),
-            globalRoles: isAuthEnabled
-              ? entry.globalRoles.map((r) => appBuilder.nameFromId(r))
-              : [],
-            instanceRoles: isAuthEnabled
-              ? entry.instanceRoles.map((r) => appBuilder.nameFromId(r))
-              : [],
-          }),
-        ),
+        exposedFields: [
+          ...fields.map(toExposedField),
+          ...foreignRelations.map((entry) => ({
+            ...toExposedField(entry),
+            paginated: entry.paginated,
+          })),
+          ...localRelations.map(toExposedField),
+        ],
         order: 1,
       }),
     },

--- a/packages/project-builder-web/src/routes/data/models/edit.$key/-components/graphql/graph-ql-object-type-section.tsx
+++ b/packages/project-builder-web/src/routes/data/models/edit.$key/-components/graphql/graph-ql-object-type-section.tsx
@@ -19,9 +19,12 @@ import {
   SectionListSectionHeader,
   SectionListSectionTitle,
   SwitchFieldController,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from '@baseplate-dev/ui-components';
 import { useController, useWatch } from 'react-hook-form';
-import { HiMiniLockClosed } from 'react-icons/hi2';
+import { HiMiniLockClosed, HiMiniQueueList } from 'react-icons/hi2';
 
 interface GraphQLObjectTypeSectionProps {
   control: Control<ModelConfigInput>;
@@ -31,6 +34,7 @@ interface FieldEntry {
   ref: string;
   globalRoles?: string[];
   instanceRoles?: string[];
+  paginated?: boolean;
 }
 
 /**
@@ -82,6 +86,19 @@ function updateEntryRoles(
 }
 
 /**
+ * Toggles the paginated flag on a specific field entry.
+ */
+function updateEntryPaginated(
+  entries: FieldEntry[],
+  ref: string,
+  paginated: boolean,
+): FieldEntry[] {
+  return entries.map((entry) =>
+    entry.ref === ref ? { ...entry, paginated } : entry,
+  );
+}
+
+/**
  * Gets the display names for roles configured on a field entry.
  */
 function getConfiguredRoleNames(
@@ -119,6 +136,7 @@ interface FieldEntryRowProps extends RoleOptions {
   allItems: { id: string }[];
   disabled: boolean;
   showAuth: boolean;
+  showPagination: boolean;
   onChange: (entries: FieldEntry[]) => void;
 }
 
@@ -131,6 +149,7 @@ function FieldEntryRow({
   allItems,
   disabled,
   showAuth,
+  showPagination,
   roleOptions,
   instanceRoleOptions,
   onChange,
@@ -157,11 +176,20 @@ function FieldEntryRow({
         <span>{label}</span>
         <div
           role="presentation"
-          className="ml-auto"
+          className="ml-auto flex items-center gap-1"
           onClick={(e) => {
             e.stopPropagation();
           }}
         >
+          {showPagination && (
+            <PaginationToggle
+              paginated={entry?.paginated ?? false}
+              disabled={!isChecked}
+              onChange={(paginated) => {
+                onChange(updateEntryPaginated(entries, entryRef, paginated));
+              }}
+            />
+          )}
           {showAuth && (
             <FieldAuthPopover
               entry={entry ?? { ref: entryRef }}
@@ -200,6 +228,7 @@ interface FieldEntryListProps extends RoleOptions {
   entries: FieldEntry[];
   disabled: boolean;
   showAuth: boolean;
+  showPagination?: boolean;
   idPrefix: string;
   onChange: (entries: FieldEntry[]) => void;
   getId?: (item: { id: string; name: string }) => string;
@@ -212,6 +241,7 @@ function FieldEntryList({
   entries,
   disabled,
   showAuth,
+  showPagination = false,
   idPrefix,
   roleOptions,
   instanceRoleOptions,
@@ -236,6 +266,7 @@ function FieldEntryList({
               allItems={items.map((i) => ({ id: getId(i) }))}
               disabled={disabled}
               showAuth={showAuth}
+              showPagination={showPagination}
               roleOptions={roleOptions}
               instanceRoleOptions={instanceRoleOptions}
               onChange={onChange}
@@ -244,6 +275,45 @@ function FieldEntryList({
         })}
       </div>
     </div>
+  );
+}
+
+interface PaginationToggleProps {
+  paginated: boolean;
+  disabled?: boolean;
+  onChange: (paginated: boolean) => void;
+}
+
+function PaginationToggle({
+  paginated,
+  disabled,
+  onChange,
+}: PaginationToggleProps): React.ReactElement {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            aria-pressed={paginated}
+            disabled={disabled}
+            className="flex h-6 items-center justify-center rounded px-1.5 hover:bg-muted disabled:pointer-events-none disabled:opacity-40"
+            onClick={() => {
+              onChange(!paginated);
+            }}
+          />
+        }
+      >
+        <HiMiniQueueList
+          className={paginated ? 'text-primary' : 'text-muted-foreground'}
+        />
+      </TooltipTrigger>
+      <TooltipContent>
+        {paginated
+          ? 'Paginated with skip/take args'
+          : 'Enable skip/take pagination args'}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -464,6 +534,7 @@ export function GraphQLObjectTypeSection({
             entries={foreignRelationsValue}
             disabled={!isObjectTypeEnabled}
             showAuth={!!isObjectTypeEnabled && hasAuthOptions}
+            showPagination={!!isObjectTypeEnabled}
             idPrefix="foreign-rel"
             roleOptions={roleOptions}
             instanceRoleOptions={instanceRoleOptions}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `skip`/`take` pagination for GraphQL to-many relationship fields (returns results ordered by `id` ascending).
  * Added a model editor toggle to enable pagination per foreign relation.
  * Pagination arguments accept non-negative integers and apply the requested offset/limit.
* **Bug Fixes**
  * Confirmed empty results are returned when `skip` exceeds the available related record count.
* **Tests**
  * Added end-to-end coverage for pagination with no args, with `skip`/`take`, and for out-of-range `skip`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->