### PR TITLE
feat: Refine eslint template for generated apps drop return type

### DIFF
--- a/.changeset/eng-1194-mirror-eslint-rules-to-monorepo.md
+++ b/.changeset/eng-1194-mirror-eslint-rules-to-monorepo.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/tools': patch
+---
+
+Brought the internal monorepo ESLint/oxlint configs in line with the refined generated-app template: switched `eslint-plugin-unicorn`'s `recommended` preset to `unopinionated` (retaining `consistent-function-scoping`, `filename-case`, and adding `no-for-loop`), consolidated `filename-case` to apply repo-wide rather than only to React packages, added `@typescript-eslint/switch-exhaustiveness-check`/`typescript/switch-exhaustiveness-check` to catch new union members silently falling into a generic `default` case, disabled `react/prop-types` as redundant with TypeScript prop typing, and promoted unused ESLint disable directives and inline configs to errors.

--- a/.changeset/eng-1194-refine-eslint-template.md
+++ b/.changeset/eng-1194-refine-eslint-template.md
@@ -1,0 +1,7 @@
+---
+'@baseplate-dev/core-generators': patch
+'@baseplate-dev/react-generators': patch
+'@baseplate-dev/plugin-auth': patch
+---
+
+Refined the ESLint template for generated apps: dropped `@typescript-eslint/explicit-function-return-type` for React components (kept for non-React TypeScript, where it remains load-bearing) and removed `@typescript-eslint/prefer-destructuring`; switched from `eslint-plugin-unicorn`'s `recommended` preset to its `unopinionated` preset while retaining the rules that matter for this codebase (`consistent-function-scoping`, `filename-case`, `no-for-loop`), and moved `filename-case` enforcement to apply to all generated apps rather than only React ones; added `@typescript-eslint/switch-exhaustiveness-check` to catch new union members silently falling into a generic `default` case; disabled `react/prop-types` for TSX files as redundant with TypeScript prop typing; and enabled `reportUnusedDisableDirectives`/`reportUnusedInlineConfigs` as warnings to surface stale ESLint directives.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
     "**/baseplate/generated/**": true
   },
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/examples/blog-with-auth/apps/admin/baseplate/generated/eslint.config.js
+++ b/examples/blog-with-auth/apps/admin/baseplate/generated/eslint.config.js
@@ -47,6 +47,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ browser /* TPL_GLOBALS:END */,
@@ -94,14 +98,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -124,6 +120,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -159,25 +157,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -185,9 +171,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -204,6 +187,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 
@@ -345,6 +345,13 @@ export default defineConfig(
           allow: ['NotFoundError', 'Redirect'],
         },
       ],
+
+      // Component return types are overwhelmingly restatements of what TS already
+      // infers from JSX (e.g. React.ReactElement); not worth the annotation noise
+      '@typescript-eslint/explicit-function-return-type': 'off',
+
+      // Pure duplication with TypeScript prop typing
+      'react/prop-types': 'off',
     },
   },
 
@@ -362,25 +369,6 @@ export default defineConfig(
 
   // Import-X
   eslintPluginImportX.flatConfigs.react,
-
-  // Unicorn
-  {
-    rules: {
-      // Support kebab case with - prefix to support ignored files in routes and $ prefix for Tanstack camelCase files
-      'unicorn/filename-case': [
-        'error',
-        {
-          cases: {
-            kebabCase: true,
-          },
-          ignore: [
-            String.raw`^-[a-z0-9\-\.]+$`,
-            String.raw`^\$[a-zA-Z0-9\.]+$`,
-          ],
-        },
-      ],
-    },
-  },
 
   // Vitest Configs
   {

--- a/examples/blog-with-auth/apps/admin/baseplate/generated/src/components/ui/calendar.tsx
+++ b/examples/blog-with-auth/apps/admin/baseplate/generated/src/components/ui/calendar.tsx
@@ -11,8 +11,6 @@ import { cn } from '@src/utils/cn';
 
 import { Button } from './button';
 
-/* eslint-disable react/prop-types -- needed for subcomponents */
-
 /**
  * A control that allows the user to select a date.
  *

--- a/examples/blog-with-auth/apps/admin/baseplate/generated/src/routes/auth_/login.tsx
+++ b/examples/blog-with-auth/apps/admin/baseplate/generated/src/routes/auth_/login.tsx
@@ -126,7 +126,7 @@ function LoginPage(): React.JSX.Element {
             });
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(err, 'Sorry, we could not log you in.'),
             );

--- a/examples/blog-with-auth/apps/admin/baseplate/generated/src/routes/auth_/register.tsx
+++ b/examples/blog-with-auth/apps/admin/baseplate/generated/src/routes/auth_/register.tsx
@@ -113,7 +113,7 @@ function RegisterPage(): React.JSX.Element {
             );
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(err, 'Sorry, we could not register you.'),
             );

--- a/examples/blog-with-auth/apps/admin/baseplate/generated/src/routes/auth_/reset-password.tsx
+++ b/examples/blog-with-auth/apps/admin/baseplate/generated/src/routes/auth_/reset-password.tsx
@@ -118,7 +118,7 @@ function ResetPasswordPage(): React.JSX.Element {
             setTokenValid(false);
             break;
           }
-          default: {
+          case null: {
             setValidationError(
               logAndFormatError(
                 err,
@@ -161,7 +161,7 @@ function ResetPasswordPage(): React.JSX.Element {
             setTokenValid(false);
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(
                 err,

--- a/examples/blog-with-auth/apps/admin/baseplate/generated/src/routes/auth_/verify-email.tsx
+++ b/examples/blog-with-auth/apps/admin/baseplate/generated/src/routes/auth_/verify-email.tsx
@@ -81,7 +81,7 @@ function VerifyEmailPage(): React.JSX.Element {
             setStatus('error');
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(err, 'Sorry, we could not verify your email.'),
             );

--- a/examples/blog-with-auth/apps/admin/eslint.config.js
+++ b/examples/blog-with-auth/apps/admin/eslint.config.js
@@ -47,6 +47,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ browser /* TPL_GLOBALS:END */,
@@ -94,14 +98,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -124,6 +120,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -159,25 +157,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -185,9 +171,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -204,6 +187,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 
@@ -345,6 +345,13 @@ export default defineConfig(
           allow: ['NotFoundError', 'Redirect'],
         },
       ],
+
+      // Component return types are overwhelmingly restatements of what TS already
+      // infers from JSX (e.g. React.ReactElement); not worth the annotation noise
+      '@typescript-eslint/explicit-function-return-type': 'off',
+
+      // Pure duplication with TypeScript prop typing
+      'react/prop-types': 'off',
     },
   },
 
@@ -362,25 +369,6 @@ export default defineConfig(
 
   // Import-X
   eslintPluginImportX.flatConfigs.react,
-
-  // Unicorn
-  {
-    rules: {
-      // Support kebab case with - prefix to support ignored files in routes and $ prefix for Tanstack camelCase files
-      'unicorn/filename-case': [
-        'error',
-        {
-          cases: {
-            kebabCase: true,
-          },
-          ignore: [
-            String.raw`^-[a-z0-9\-\.]+$`,
-            String.raw`^\$[a-zA-Z0-9\.]+$`,
-          ],
-        },
-      ],
-    },
-  },
 
   // Vitest Configs
   {

--- a/examples/blog-with-auth/apps/admin/src/components/ui/calendar.tsx
+++ b/examples/blog-with-auth/apps/admin/src/components/ui/calendar.tsx
@@ -11,8 +11,6 @@ import { cn } from '@src/utils/cn';
 
 import { Button } from './button';
 
-/* eslint-disable react/prop-types -- needed for subcomponents */
-
 /**
  * A control that allows the user to select a date.
  *

--- a/examples/blog-with-auth/apps/admin/src/routes/auth_/login.tsx
+++ b/examples/blog-with-auth/apps/admin/src/routes/auth_/login.tsx
@@ -126,7 +126,7 @@ function LoginPage(): React.JSX.Element {
             });
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(err, 'Sorry, we could not log you in.'),
             );

--- a/examples/blog-with-auth/apps/admin/src/routes/auth_/register.tsx
+++ b/examples/blog-with-auth/apps/admin/src/routes/auth_/register.tsx
@@ -113,7 +113,7 @@ function RegisterPage(): React.JSX.Element {
             );
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(err, 'Sorry, we could not register you.'),
             );

--- a/examples/blog-with-auth/apps/admin/src/routes/auth_/reset-password.tsx
+++ b/examples/blog-with-auth/apps/admin/src/routes/auth_/reset-password.tsx
@@ -118,7 +118,7 @@ function ResetPasswordPage(): React.JSX.Element {
             setTokenValid(false);
             break;
           }
-          default: {
+          case null: {
             setValidationError(
               logAndFormatError(
                 err,
@@ -161,7 +161,7 @@ function ResetPasswordPage(): React.JSX.Element {
             setTokenValid(false);
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(
                 err,

--- a/examples/blog-with-auth/apps/admin/src/routes/auth_/verify-email.tsx
+++ b/examples/blog-with-auth/apps/admin/src/routes/auth_/verify-email.tsx
@@ -81,7 +81,7 @@ function VerifyEmailPage(): React.JSX.Element {
             setStatus('error');
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(err, 'Sorry, we could not verify your email.'),
             );

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/eslint.config.js
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/eslint.config.js
@@ -43,6 +43,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ node /* TPL_GLOBALS:END */,
@@ -90,14 +94,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -120,6 +116,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -155,25 +153,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -181,9 +167,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -200,6 +183,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 

--- a/examples/blog-with-auth/apps/backend/eslint.config.js
+++ b/examples/blog-with-auth/apps/backend/eslint.config.js
@@ -43,6 +43,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ node /* TPL_GLOBALS:END */,
@@ -90,14 +94,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -120,6 +116,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -155,25 +153,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -181,9 +167,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -200,6 +183,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 

--- a/examples/blog-with-auth/libs/transactional/baseplate/generated/eslint.config.js
+++ b/examples/blog-with-auth/libs/transactional/baseplate/generated/eslint.config.js
@@ -41,6 +41,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ node /* TPL_GLOBALS:END */,
@@ -88,14 +92,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -118,6 +114,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -153,25 +151,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -179,9 +165,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -198,6 +181,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 

--- a/examples/blog-with-auth/libs/transactional/eslint.config.js
+++ b/examples/blog-with-auth/libs/transactional/eslint.config.js
@@ -41,6 +41,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ node /* TPL_GLOBALS:END */,
@@ -88,14 +92,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -118,6 +114,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -153,25 +151,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -179,9 +165,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -198,6 +181,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 

--- a/examples/todo-with-better-auth/apps/admin/baseplate/generated/eslint.config.js
+++ b/examples/todo-with-better-auth/apps/admin/baseplate/generated/eslint.config.js
@@ -47,6 +47,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ browser /* TPL_GLOBALS:END */,
@@ -94,14 +98,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -124,6 +120,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -159,25 +157,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -185,9 +171,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -204,6 +187,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 
@@ -345,6 +345,13 @@ export default defineConfig(
           allow: ['NotFoundError', 'Redirect'],
         },
       ],
+
+      // Component return types are overwhelmingly restatements of what TS already
+      // infers from JSX (e.g. React.ReactElement); not worth the annotation noise
+      '@typescript-eslint/explicit-function-return-type': 'off',
+
+      // Pure duplication with TypeScript prop typing
+      'react/prop-types': 'off',
     },
   },
 
@@ -362,25 +369,6 @@ export default defineConfig(
 
   // Import-X
   eslintPluginImportX.flatConfigs.react,
-
-  // Unicorn
-  {
-    rules: {
-      // Support kebab case with - prefix to support ignored files in routes and $ prefix for Tanstack camelCase files
-      'unicorn/filename-case': [
-        'error',
-        {
-          cases: {
-            kebabCase: true,
-          },
-          ignore: [
-            String.raw`^-[a-z0-9\-\.]+$`,
-            String.raw`^\$[a-zA-Z0-9\.]+$`,
-          ],
-        },
-      ],
-    },
-  },
 
   // Vitest Configs
   {

--- a/examples/todo-with-better-auth/apps/admin/baseplate/generated/src/components/ui/calendar.tsx
+++ b/examples/todo-with-better-auth/apps/admin/baseplate/generated/src/components/ui/calendar.tsx
@@ -11,8 +11,6 @@ import { cn } from '@src/utils/cn';
 
 import { Button } from './button';
 
-/* eslint-disable react/prop-types -- needed for subcomponents */
-
 /**
  * A control that allows the user to select a date.
  *

--- a/examples/todo-with-better-auth/apps/admin/eslint.config.js
+++ b/examples/todo-with-better-auth/apps/admin/eslint.config.js
@@ -47,6 +47,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ browser /* TPL_GLOBALS:END */,
@@ -94,14 +98,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -124,6 +120,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -159,25 +157,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -185,9 +171,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -204,6 +187,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 
@@ -345,6 +345,13 @@ export default defineConfig(
           allow: ['NotFoundError', 'Redirect'],
         },
       ],
+
+      // Component return types are overwhelmingly restatements of what TS already
+      // infers from JSX (e.g. React.ReactElement); not worth the annotation noise
+      '@typescript-eslint/explicit-function-return-type': 'off',
+
+      // Pure duplication with TypeScript prop typing
+      'react/prop-types': 'off',
     },
   },
 
@@ -362,25 +369,6 @@ export default defineConfig(
 
   // Import-X
   eslintPluginImportX.flatConfigs.react,
-
-  // Unicorn
-  {
-    rules: {
-      // Support kebab case with - prefix to support ignored files in routes and $ prefix for Tanstack camelCase files
-      'unicorn/filename-case': [
-        'error',
-        {
-          cases: {
-            kebabCase: true,
-          },
-          ignore: [
-            String.raw`^-[a-z0-9\-\.]+$`,
-            String.raw`^\$[a-zA-Z0-9\.]+$`,
-          ],
-        },
-      ],
-    },
-  },
 
   // Vitest Configs
   {

--- a/examples/todo-with-better-auth/apps/admin/src/components/ui/calendar.tsx
+++ b/examples/todo-with-better-auth/apps/admin/src/components/ui/calendar.tsx
@@ -11,8 +11,6 @@ import { cn } from '@src/utils/cn';
 
 import { Button } from './button';
 
-/* eslint-disable react/prop-types -- needed for subcomponents */
-
 /**
  * A control that allows the user to select a date.
  *

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/eslint.config.js
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/eslint.config.js
@@ -43,6 +43,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ node /* TPL_GLOBALS:END */,
@@ -90,14 +94,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -120,6 +116,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -155,25 +153,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -181,9 +167,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -200,6 +183,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 

--- a/examples/todo-with-better-auth/apps/backend/eslint.config.js
+++ b/examples/todo-with-better-auth/apps/backend/eslint.config.js
@@ -43,6 +43,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ node /* TPL_GLOBALS:END */,
@@ -90,14 +94,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -120,6 +116,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -155,25 +153,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -181,9 +167,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -200,6 +183,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 

--- a/examples/todo-with-better-auth/apps/web/baseplate/generated/eslint.config.js
+++ b/examples/todo-with-better-auth/apps/web/baseplate/generated/eslint.config.js
@@ -47,6 +47,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ browser /* TPL_GLOBALS:END */,
@@ -94,14 +98,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -124,6 +120,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -159,25 +157,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -185,9 +171,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -204,6 +187,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 
@@ -345,6 +345,13 @@ export default defineConfig(
           allow: ['NotFoundError', 'Redirect'],
         },
       ],
+
+      // Component return types are overwhelmingly restatements of what TS already
+      // infers from JSX (e.g. React.ReactElement); not worth the annotation noise
+      '@typescript-eslint/explicit-function-return-type': 'off',
+
+      // Pure duplication with TypeScript prop typing
+      'react/prop-types': 'off',
     },
   },
 
@@ -362,25 +369,6 @@ export default defineConfig(
 
   // Import-X
   eslintPluginImportX.flatConfigs.react,
-
-  // Unicorn
-  {
-    rules: {
-      // Support kebab case with - prefix to support ignored files in routes and $ prefix for Tanstack camelCase files
-      'unicorn/filename-case': [
-        'error',
-        {
-          cases: {
-            kebabCase: true,
-          },
-          ignore: [
-            String.raw`^-[a-z0-9\-\.]+$`,
-            String.raw`^\$[a-zA-Z0-9\.]+$`,
-          ],
-        },
-      ],
-    },
-  },
 
   // Vitest Configs
   {

--- a/examples/todo-with-better-auth/apps/web/baseplate/generated/src/components/ui/calendar.tsx
+++ b/examples/todo-with-better-auth/apps/web/baseplate/generated/src/components/ui/calendar.tsx
@@ -11,8 +11,6 @@ import { cn } from '@src/utils/cn';
 
 import { Button } from './button';
 
-/* eslint-disable react/prop-types -- needed for subcomponents */
-
 /**
  * A control that allows the user to select a date.
  *

--- a/examples/todo-with-better-auth/apps/web/eslint.config.js
+++ b/examples/todo-with-better-auth/apps/web/eslint.config.js
@@ -47,6 +47,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ browser /* TPL_GLOBALS:END */,
@@ -94,14 +98,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -124,6 +120,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -159,25 +157,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -185,9 +171,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -204,6 +187,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 
@@ -345,6 +345,13 @@ export default defineConfig(
           allow: ['NotFoundError', 'Redirect'],
         },
       ],
+
+      // Component return types are overwhelmingly restatements of what TS already
+      // infers from JSX (e.g. React.ReactElement); not worth the annotation noise
+      '@typescript-eslint/explicit-function-return-type': 'off',
+
+      // Pure duplication with TypeScript prop typing
+      'react/prop-types': 'off',
     },
   },
 
@@ -362,25 +369,6 @@ export default defineConfig(
 
   // Import-X
   eslintPluginImportX.flatConfigs.react,
-
-  // Unicorn
-  {
-    rules: {
-      // Support kebab case with - prefix to support ignored files in routes and $ prefix for Tanstack camelCase files
-      'unicorn/filename-case': [
-        'error',
-        {
-          cases: {
-            kebabCase: true,
-          },
-          ignore: [
-            String.raw`^-[a-z0-9\-\.]+$`,
-            String.raw`^\$[a-zA-Z0-9\.]+$`,
-          ],
-        },
-      ],
-    },
-  },
 
   // Vitest Configs
   {

--- a/examples/todo-with-better-auth/apps/web/src/components/ui/calendar.tsx
+++ b/examples/todo-with-better-auth/apps/web/src/components/ui/calendar.tsx
@@ -11,8 +11,6 @@ import { cn } from '@src/utils/cn';
 
 import { Button } from './button';
 
-/* eslint-disable react/prop-types -- needed for subcomponents */
-
 /**
  * A control that allows the user to select a date.
  *

--- a/examples/todo-with-better-auth/libs/transactional/baseplate/generated/eslint.config.js
+++ b/examples/todo-with-better-auth/libs/transactional/baseplate/generated/eslint.config.js
@@ -41,6 +41,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ node /* TPL_GLOBALS:END */,
@@ -88,14 +92,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -118,6 +114,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -153,25 +151,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -179,9 +165,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -198,6 +181,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 

--- a/examples/todo-with-better-auth/libs/transactional/eslint.config.js
+++ b/examples/todo-with-better-auth/libs/transactional/eslint.config.js
@@ -41,6 +41,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals./* TPL_GLOBALS:START */ node /* TPL_GLOBALS:END */,
@@ -88,14 +92,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -118,6 +114,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -153,25 +151,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -179,9 +165,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -198,6 +181,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 

--- a/packages/core-generators/src/generators/node/eslint/react-rules.ts
+++ b/packages/core-generators/src/generators/node/eslint/react-rules.ts
@@ -40,6 +40,13 @@ export const REACT_ESLINT_RULES = tsCodeFragment(
           allow: ['NotFoundError', 'Redirect'],
         },
       ],
+
+      // Component return types are overwhelmingly restatements of what TS already
+      // infers from JSX (e.g. React.ReactElement); not worth the annotation noise
+      '@typescript-eslint/explicit-function-return-type': 'off',
+
+      // Pure duplication with TypeScript prop typing
+      'react/prop-types': 'off',
     },
   },
 
@@ -57,22 +64,6 @@ export const REACT_ESLINT_RULES = tsCodeFragment(
 
   // Import-X
   eslintPluginImportX.flatConfigs.react,
-
-  // Unicorn
-  {
-    rules: {
-      // Support kebab case with - prefix to support ignored files in routes and $ prefix for Tanstack camelCase files
-      'unicorn/filename-case': [
-        'error',
-        {
-          cases: {
-            kebabCase: true,
-          },
-          ignore: [String.raw\`^-[a-z0-9\\-\\.]+$\`, String.raw\`^\\$[a-zA-Z0-9\\.]+$\`],
-        },
-      ],
-    },
-  },
 `,
   [
     tsImportBuilder()

--- a/packages/core-generators/src/generators/node/eslint/templates/eslint.config.js
+++ b/packages/core-generators/src/generators/node/eslint/templates/eslint.config.js
@@ -27,6 +27,10 @@ export default defineConfig(
   // ESLint Configs for all files
   eslint.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'warn',
+      reportUnusedInlineConfigs: 'warn',
+    },
     languageOptions: {
       globals: {
         ...globals.TPL_GLOBALS,
@@ -74,14 +78,6 @@ export default defineConfig(
         'error',
         { allowExpressions: true, allowTypedFunctionExpressions: true },
       ],
-      // Enforce the use of destructuring for objects where applicable, but not for arrays
-      '@typescript-eslint/prefer-destructuring': [
-        'error',
-        {
-          VariableDeclarator: { object: true, array: false },
-          AssignmentExpression: { object: false, array: false },
-        },
-      ],
       // Ensure consistent usage of type exports
       '@typescript-eslint/consistent-type-exports': 'error',
       // Ensure consistent usage of type imports
@@ -104,6 +100,8 @@ export default defineConfig(
         'error',
         { ignoreTernaryTests: true },
       ],
+      // Catch new union members silently falling into a generic `default` case
+      '@typescript-eslint/switch-exhaustiveness-check': 'error',
     },
   },
 
@@ -139,25 +137,13 @@ export default defineConfig(
   },
 
   // Unicorn Configs
-  eslintPluginUnicorn.configs['recommended'],
+  eslintPluginUnicorn.configs['unopinionated'],
   {
     rules: {
-      // Disable the rule that prevents using abbreviations in identifiers, allowing
-      // flexibility in naming, especially for common abbreviations in code.
-      'unicorn/prevent-abbreviations': 'off',
-
-      // Disable the rule that disallows `null` values, allowing `null` to be used
-      // when necessary (e.g., for nullable types or optional fields).
-      'unicorn/no-null': 'off',
-
-      // Allow array callback references without flags, supporting patterns like
-      // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-      'unicorn/no-array-callback-reference': 'off',
-
       // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
       'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-      // Allow the use of arrow functions in nested scopes
+      // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
       'unicorn/consistent-function-scoping': [
         'error',
         { checkArrowFunctions: false },
@@ -165,9 +151,6 @@ export default defineConfig(
 
       // A bit over-eager flagging any module references
       'unicorn/prefer-module': 'off',
-
-      // Allow error variables to be named anything
-      'unicorn/catch-error-name': 'off',
 
       // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
       'unicorn/no-array-method-this-argument': 'off',
@@ -184,6 +167,23 @@ export default defineConfig(
       // Allow usage of utf-8 text encoding since it's consistent with the WHATWG spec
       // and autofixing can cause unexpected changes (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1926)
       'unicorn/text-encoding-identifier-case': 'off',
+
+      // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+      'unicorn/no-for-loop': 'error',
+
+      // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+      'unicorn/filename-case': [
+        'error',
+        {
+          cases: {
+            kebabCase: true,
+          },
+          ignore: [
+            String.raw`^-[a-z0-9\-\.]+$`,
+            String.raw`^\$[a-zA-Z0-9\.]+$`,
+          ],
+        },
+      ],
     },
   },
 

--- a/packages/react-generators/src/generators/core/react-components/templates/components/ui/calendar.tsx
+++ b/packages/react-generators/src/generators/core/react-components/templates/components/ui/calendar.tsx
@@ -11,8 +11,6 @@ import * as React from 'react';
 import { DayPicker, getDefaultClassNames } from 'react-day-picker';
 import { MdChevronLeft, MdChevronRight, MdExpandMore } from 'react-icons/md';
 
-/* eslint-disable react/prop-types -- needed for subcomponents */
-
 /**
  * A control that allows the user to select a date.
  *

--- a/packages/tools/eslint-configs/react.js
+++ b/packages/tools/eslint-configs/react.js
@@ -69,6 +69,9 @@ export function generateReactEslintConfig(options) {
             allowForKnownSafeCalls: ['UseNavigateResult'],
           },
         ],
+
+        // Pure duplication with TypeScript prop typing
+        'react/prop-types': 'off',
       },
     },
 
@@ -112,25 +115,6 @@ export function generateReactEslintConfig(options) {
           },
         ])
       : []),
-
-    // Unicorn
-    {
-      rules: {
-        // Support kebab case with - prefix to support ignored files in routes and $ prefix for Tanstack camelCase files
-        'unicorn/filename-case': [
-          'error',
-          {
-            cases: {
-              kebabCase: true,
-            },
-            ignore: [
-              String.raw`^-[a-z0-9\-\.]+$`,
-              String.raw`^\$[a-zA-Z0-9\.]+$`,
-            ],
-          },
-        ],
-      },
-    },
 
     // Global ignores
     {

--- a/packages/tools/eslint-configs/typescript.js
+++ b/packages/tools/eslint-configs/typescript.js
@@ -62,6 +62,10 @@ export function generateTypescriptEslintConfig(options = {}) {
     // ESLint Configs for all files
     eslint.configs.recommended,
     {
+      linterOptions: {
+        reportUnusedDisableDirectives: 'error',
+        reportUnusedInlineConfigs: 'error',
+      },
       languageOptions: {
         globals: { ...globals.node },
       },
@@ -134,6 +138,10 @@ export function generateTypescriptEslintConfig(options = {}) {
           'error',
           { ignoreTernaryTests: true },
         ],
+        // Catch new union members silently falling into a generic `default` case.
+        // A `default` clause still satisfies exhaustiveness for switches with no
+        // missing cases (allowDefaultCaseForExhaustiveSwitch, on by default).
+        '@typescript-eslint/switch-exhaustiveness-check': 'error',
 
         // Allow redirect and notFound to be thrown from routes (placing in generic config to allow it to be used in *.ts files too)
         '@typescript-eslint/only-throw-error': [
@@ -206,25 +214,13 @@ export function generateTypescriptEslintConfig(options = {}) {
     },
 
     // Unicorn Configs
-    eslintPluginUnicorn.configs.recommended,
+    eslintPluginUnicorn.configs.unopinionated,
     {
       rules: {
-        // Disable the rule that prevents using abbreviations in identifiers, allowing
-        // flexibility in naming, especially for common abbreviations in code.
-        'unicorn/prevent-abbreviations': 'off',
-
-        // Disable the rule that disallows `null` values, allowing `null` to be used
-        // when necessary (e.g., for nullable types or optional fields).
-        'unicorn/no-null': 'off',
-
-        // Allow array callback references without flags, supporting patterns like
-        // `array.filter(callbackFunction)`, which can improve readability and code brevity.
-        'unicorn/no-array-callback-reference': 'off',
-
         // Allow ternary operators to be used when appropriate (this conflicts with https://typescript-eslint.io/rules/prefer-nullish-coalescing/)
         'unicorn/prefer-logical-operator-over-ternary': 'off',
 
-        // Allow the use of arrow functions in nested scopes
+        // Re-enable with the arrow-function carve-out since the unopinionated preset omits this rule by default
         'unicorn/consistent-function-scoping': [
           'error',
           { checkArrowFunctions: false },
@@ -232,9 +228,6 @@ export function generateTypescriptEslintConfig(options = {}) {
 
         // A bit over-eager flagging any module references
         'unicorn/prefer-module': 'off',
-
-        // Allow error variables to be named anything
-        'unicorn/catch-error-name': 'off',
 
         // False positives with array-like functions (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1394)
         'unicorn/no-array-method-this-argument': 'off',
@@ -248,6 +241,23 @@ export function generateTypescriptEslintConfig(options = {}) {
 
         // This rule can cause performance issues (https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2819)
         'unicorn/no-unnecessary-polyfills': 'off',
+
+        // Enforce for-of/array methods over manual index loops; the unopinionated preset omits this rule by default
+        'unicorn/no-for-loop': 'error',
+
+        // Enforce kebab-case filenames (repo convention); the unopinionated preset omits this rule by default
+        'unicorn/filename-case': [
+          'error',
+          {
+            cases: {
+              kebabCase: true,
+            },
+            ignore: [
+              String.raw`^-[a-z0-9\-\.]+$`,
+              String.raw`^\$[a-zA-Z0-9\.]+$`,
+            ],
+          },
+        ],
       },
     },
 

--- a/packages/tools/oxlint.config.base.js
+++ b/packages/tools/oxlint.config.base.js
@@ -211,6 +211,14 @@ export const oxlintConfigBase = {
       'error',
       { allowExpressions: true, allowTypedFunctionExpressions: true },
     ],
+    // Catch new union members with no case handling at all; a `default` clause
+    // is treated as covering the remaining members since it's a common,
+    // intentional fallback pattern in this codebase. Needed explicitly here since
+    // oxlint's rule (unlike @typescript-eslint's) does not default to this behavior.
+    'typescript/switch-exhaustiveness-check': [
+      'error',
+      { considerDefaultExhaustiveForUnions: true },
+    ],
 
     // Unicorn rules
     'unicorn/consistent-assert': 'error',

--- a/packages/ui-components/src/components/ui/calendar/calendar.tsx
+++ b/packages/ui-components/src/components/ui/calendar/calendar.tsx
@@ -11,8 +11,6 @@ import { cn } from '#src/utils/index.js';
 
 import { Button } from '../button/button.js';
 
-/* eslint-disable react/prop-types -- needed for subcomponents */
-
 /**
  * A control that allows the user to select a date.
  *

--- a/plugins/plugin-auth/src/local-auth/core/generators/auth-routes/templates/routes/auth_/login.tsx
+++ b/plugins/plugin-auth/src/local-auth/core/generators/auth-routes/templates/routes/auth_/login.tsx
@@ -125,7 +125,7 @@ function LoginPage(): React.JSX.Element {
             });
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(err, 'Sorry, we could not log you in.'),
             );

--- a/plugins/plugin-auth/src/local-auth/core/generators/auth-routes/templates/routes/auth_/register.tsx
+++ b/plugins/plugin-auth/src/local-auth/core/generators/auth-routes/templates/routes/auth_/register.tsx
@@ -95,7 +95,7 @@ function RegisterPage(): React.JSX.Element {
             );
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(err, 'Sorry, we could not register you.'),
             );

--- a/plugins/plugin-auth/src/local-auth/core/generators/auth-routes/templates/routes/auth_/reset-password.tsx
+++ b/plugins/plugin-auth/src/local-auth/core/generators/auth-routes/templates/routes/auth_/reset-password.tsx
@@ -117,7 +117,7 @@ function ResetPasswordPage(): React.JSX.Element {
             setTokenValid(false);
             break;
           }
-          default: {
+          case null: {
             setValidationError(
               logAndFormatError(
                 err,
@@ -160,7 +160,7 @@ function ResetPasswordPage(): React.JSX.Element {
             setTokenValid(false);
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(
                 err,

--- a/plugins/plugin-auth/src/local-auth/core/generators/auth-routes/templates/routes/auth_/verify-email.tsx
+++ b/plugins/plugin-auth/src/local-auth/core/generators/auth-routes/templates/routes/auth_/verify-email.tsx
@@ -81,7 +81,7 @@ function VerifyEmailPage(): React.JSX.Element {
             setStatus('error');
             break;
           }
-          default: {
+          case null: {
             toast.error(
               logAndFormatError(err, 'Sorry, we could not verify your email.'),
             );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Generated applications now enforce more consistent filename casing and discourage manual `for` loops.
  * Added checks to identify non-exhaustive `switch` statements.
  * Improved handling and reporting of unused lint directives and inline configurations.
  * Updated TypeScript React linting to avoid redundant prop-type and return-type requirements.

* **Bug Fixes**
  * Authentication error handling now explicitly handles missing error codes for clearer fallback behavior.

* **Developer Experience**
  * VS Code now uses the workspace TypeScript SDK automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->