### PR TITLE
feat: Added `r.userMatch` and `r.userWhere` role-builder verbs

### DIFF
--- a/.changeset/eng-1134-user-match-user-where.md
+++ b/.changeset/eng-1134-user-match-user-where.md
@@ -1,0 +1,6 @@
+---
+'@baseplate-dev/fastify-generators': patch
+'@baseplate-dev/project-builder-server': patch
+---
+
+Added `r.userMatch` and `r.userWhere` role-builder verbs alongside `r.match`/`r.where`, for role predicates keyed on the authenticated user's id. Their callback only runs for an authenticated principal (receiving the session with `userId` guaranteed non-null), so the generated policy no longer needs a per-role `ctx.auth.userId != null ? {...} : false` guard — an anonymous caller is denied automatically before the callback runs.

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/accounts/users/authorizers/user.policy.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/accounts/users/authorizers/user.policy.ts
@@ -5,11 +5,7 @@ export const userPolicy = createModelPolicy({
   model: 'user',
   idField: 'id',
   delegate: prisma.user,
-  roles: (r) => ({
-    self: r.match((ctx) =>
-      ctx.auth.userId != null ? { id: ctx.auth.userId } : false,
-    ),
-  }),
+  roles: (r) => ({ self: r.userMatch((session) => ({ id: session.userId })) }),
   actions: {
     read: { globalRoles: ['user', 'admin'] },
     create: { globalRoles: ['admin'] },

--- a/examples/blog-with-auth/apps/backend/src/modules/accounts/users/authorizers/user.policy.ts
+++ b/examples/blog-with-auth/apps/backend/src/modules/accounts/users/authorizers/user.policy.ts
@@ -5,11 +5,7 @@ export const userPolicy = createModelPolicy({
   model: 'user',
   idField: 'id',
   delegate: prisma.user,
-  roles: (r) => ({
-    self: r.match((ctx) =>
-      ctx.auth.userId != null ? { id: ctx.auth.userId } : false,
-    ),
-  }),
+  roles: (r) => ({ self: r.userMatch((session) => ({ id: session.userId })) }),
   actions: {
     read: { globalRoles: ['user', 'admin'] },
     create: { globalRoles: ['admin'] },

--- a/examples/blog-with-auth/apps/backend/src/modules/blogs/authorizers/blog.policy.ts
+++ b/examples/blog-with-auth/apps/backend/src/modules/blogs/authorizers/blog.policy.ts
@@ -6,14 +6,10 @@ export const blogPolicy = createModelPolicy({
   idField: 'id',
   delegate: prisma.blog,
   roles: (r) => ({
-    owner: r.match((ctx) =>
-      ctx.auth.userId != null ? { userId: ctx.auth.userId } : false,
-    ),
-    viewer: r.where((ctx) =>
-      ctx.auth.userId != null
-        ? { members: { some: { userId: ctx.auth.userId } } }
-        : false,
-    ),
+    owner: r.userMatch((session) => ({ userId: session.userId })),
+    viewer: r.userWhere((session) => ({
+      members: { some: { userId: session.userId } },
+    })),
   }),
   actions: {
     read: { globalRoles: ['public'] },

--- a/examples/blog-with-auth/apps/backend/src/utils/authorizers.ts
+++ b/examples/blog-with-auth/apps/backend/src/utils/authorizers.ts
@@ -1,5 +1,6 @@
 import type { Prisma, PrismaClient } from '../generated/prisma/client.js';
 import type { AuthRole } from '../modules/accounts/auth/constants/auth-roles.constants.js';
+import type { AuthUserSessionInfo } from '../modules/accounts/auth/types/auth-session.types.js';
 import type {
   GetResult,
   ModelPropName,
@@ -117,8 +118,10 @@ interface ViaLink<M extends ModelPropName, R extends ToOneRelationKeys<M>> {
 // createModelPolicy — one declaration per role; the boolean `check` and the
 // Prisma `where` are BOTH derived, with cached delegation (not a per-child
 // probe). Role kinds:
-//   match   — scalar equality on self (zero-query on a loaded row)
-//   where   — arbitrary Prisma filter (DB-evaluated)
+//   match     — scalar equality on self (zero-query on a loaded row)
+//   userMatch — like `match`, but only for an authenticated principal (auto-denies anonymous)
+//   where     — arbitrary Prisma filter (DB-evaluated)
+//   userWhere — like `where`, but only for an authenticated principal (auto-denies anonymous)
 //   via     — cached delegation to a parent policy's role
 //   hasRole — global/principal-role leaf, nestable
 //   authenticated — held if there is any logged-in principal
@@ -191,6 +194,32 @@ interface PredicateRole<TModelName extends ModelPropName> {
   kind: 'where';
   where: (ctx: ServiceContext) => WhereResult<TModelName>;
 }
+/**
+ * `r.userMatch` — like `r.match`, but the callback only runs for an
+ * authenticated principal (a `type: 'user'` session), receiving that session
+ * (`userId` guaranteed non-null) alongside `ctx`. Unauthenticated → deny,
+ * callback never invoked. Removes the per-callsite
+ * `ctx.auth.userId != null ? {...} : false` guard.
+ */
+interface UserMatchRole<TModelName extends ModelPropName> {
+  kind: 'userMatch';
+  userMatch: (
+    session: AuthUserSessionInfo,
+    ctx: ServiceContext,
+  ) => LocalMatch<TModelName> | false;
+}
+/**
+ * `r.userWhere` — like `r.where`, but the callback only runs for an
+ * authenticated principal (a `type: 'user'` session), receiving that session
+ * (`userId` guaranteed non-null) alongside `ctx`.
+ */
+interface UserWhereRole<TModelName extends ModelPropName> {
+  kind: 'userWhere';
+  userWhere: (
+    session: AuthUserSessionInfo,
+    ctx: ServiceContext,
+  ) => WhereResult<TModelName>;
+}
 /** `r.via` — delegate to a parent policy's role through a FK (cached checkById). */
 interface ViaRole<TModelName extends ModelPropName> {
   kind: 'via';
@@ -245,7 +274,9 @@ interface CheckRole<TModelName extends ModelPropName> {
  */
 type RoleNode<TModelName extends ModelPropName> =
   | MatchRole<TModelName>
+  | UserMatchRole<TModelName>
   | PredicateRole<TModelName>
+  | UserWhereRole<TModelName>
   | ViaRole<TModelName>
   | HasRoleLeaf
   | AuthenticatedLeaf
@@ -268,6 +299,28 @@ export interface RoleBuilder<TModelName extends ModelPropName> {
   where: (
     where: (ctx: ServiceContext) => WhereResult<TModelName>,
   ) => PredicateRole<TModelName>;
+  /**
+   * Authenticated scalar-equality fast path (zero-query). Callback only runs
+   * for a `type: 'user'` session — unauthenticated denies without calling it.
+   * See `UserMatchRole`.
+   */
+  userMatch: (
+    userMatch: (
+      session: AuthUserSessionInfo,
+      ctx: ServiceContext,
+    ) => LocalMatch<TModelName> | false,
+  ) => UserMatchRole<TModelName>;
+  /**
+   * Authenticated Prisma filter (DB-evaluated). Callback only runs for a
+   * `type: 'user'` session — unauthenticated denies without calling it. See
+   * `UserWhereRole`.
+   */
+  userWhere: (
+    userWhere: (
+      session: AuthUserSessionInfo,
+      ctx: ServiceContext,
+    ) => WhereResult<TModelName>,
+  ) => UserWhereRole<TModelName>;
   /**
    * Delegate to a parent policy's role through a FK (cached checkById). The
    * type checks `relation` is a to-one key and `fk` is a scalar of this model,
@@ -534,7 +587,9 @@ export function createModelPolicy<
 
   const builder: RoleBuilder<TModelName> = {
     match: (match) => ({ kind: 'match', match }),
+    userMatch: (userMatch) => ({ kind: 'userMatch', userMatch }),
     where: (where) => ({ kind: 'where', where }),
+    userWhere: (userWhere) => ({ kind: 'userWhere', userWhere }),
     via: (target, role, link) => ({
       kind: 'via',
       target,
@@ -598,7 +653,10 @@ export function createModelPolicy<
     parts: readonly RoleNode<TModelName>[],
   ): { node: RoleNode<TModelName>; i: number }[] {
     const cheap = (n: RoleNode<TModelName>): number =>
-      n.kind === 'match' || n.kind === 'hasRole' || n.kind === 'authenticated'
+      n.kind === 'match' ||
+      n.kind === 'userMatch' ||
+      n.kind === 'hasRole' ||
+      n.kind === 'authenticated'
         ? 0
         : 1;
     return parts
@@ -622,11 +680,26 @@ export function createModelPolicy<
         validateMatch(m, key);
         return m;
       }
+      case 'userMatch': {
+        // Deny BEFORE invoking the callback if unauthenticated — the callback's
+        // session is guaranteed `type: 'user'` (non-null `userId`).
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        const m = node.userMatch(session, ctx);
+        if (m === false) return false;
+        validateMatch(m, key);
+        return m;
+      }
       case 'via': {
         return node.target.roles[node.role].nestedWhere(ctx, node.relation);
       }
       case 'where': {
         return assertNotUndefined(node.where(ctx), key);
+      }
+      case 'userWhere': {
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        return assertNotUndefined(node.userWhere(session, ctx), key);
       }
       case 'hasRole': {
         // Held → unrestricted (`true` folds through queryHelpers); else `false`
@@ -674,6 +747,13 @@ export function createModelPolicy<
         if (m === false) return false;
         return evaluateMatch(m, model, key);
       }
+      case 'userMatch': {
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        const m = node.userMatch(session, ctx);
+        if (m === false) return false;
+        return evaluateMatch(m, model, key);
+      }
       case 'via': {
         // Delegation: parent's cached checkById, keyed on the PARENT id → N
         // children of one parent collapse to 1 query, even concurrently.
@@ -682,6 +762,17 @@ export function createModelPolicy<
       }
       case 'where': {
         const where = assertNotUndefined(node.where(ctx), key);
+        if (where === true) return true;
+        if (where === false) return false;
+        const id = String(model[config.idField]);
+        return cachedBoolean(ctx, roleCacheKey(id, key), () =>
+          exists(ctx, id, where),
+        );
+      }
+      case 'userWhere': {
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        const where = assertNotUndefined(node.userWhere(session, ctx), key);
         if (where === true) return true;
         if (where === false) return false;
         const id = String(model[config.idField]);

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/accounts/users/authorizers/user.policy.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/accounts/users/authorizers/user.policy.ts
@@ -5,11 +5,7 @@ export const userPolicy = createModelPolicy({
   model: 'user',
   idField: 'id',
   delegate: prisma.user,
-  roles: (r) => ({
-    self: r.match((ctx) =>
-      ctx.auth.userId != null ? { id: ctx.auth.userId } : false,
-    ),
-  }),
+  roles: (r) => ({ self: r.userMatch((session) => ({ id: session.userId })) }),
   actions: {
     read: { globalRoles: ['user'] },
     create: { globalRoles: ['admin'] },

--- a/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/authorizers/user.policy.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/authorizers/user.policy.ts
@@ -5,11 +5,7 @@ export const userPolicy = createModelPolicy({
   model: 'user',
   idField: 'id',
   delegate: prisma.user,
-  roles: (r) => ({
-    self: r.match((ctx) =>
-      ctx.auth.userId != null ? { id: ctx.auth.userId } : false,
-    ),
-  }),
+  roles: (r) => ({ self: r.userMatch((session) => ({ id: session.userId })) }),
   actions: {
     read: { globalRoles: ['user'] },
     create: { globalRoles: ['admin'] },

--- a/examples/todo-with-better-auth/apps/backend/src/modules/todos/authorizers/todo-list.policy.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/todos/authorizers/todo-list.policy.ts
@@ -6,9 +6,7 @@ export const todoListPolicy = createModelPolicy({
   idField: 'id',
   delegate: prisma.todoList,
   roles: (r) => ({
-    owner: r.match((ctx) =>
-      ctx.auth.userId != null ? { ownerId: ctx.auth.userId } : false,
-    ),
+    owner: r.userMatch((session) => ({ ownerId: session.userId })),
   }),
   actions: {
     read: { roles: ['owner'], globalRoles: ['admin'] },

--- a/examples/todo-with-better-auth/apps/backend/src/utils/authorizers.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/utils/authorizers.ts
@@ -1,5 +1,6 @@
 import type { Prisma, PrismaClient } from '../generated/prisma/client.js';
 import type { AuthRole } from '../modules/accounts/auth/constants/auth-roles.constants.js';
+import type { AuthUserSessionInfo } from '../modules/accounts/auth/types/auth-session.types.js';
 import type {
   GetResult,
   ModelPropName,
@@ -117,8 +118,10 @@ interface ViaLink<M extends ModelPropName, R extends ToOneRelationKeys<M>> {
 // createModelPolicy — one declaration per role; the boolean `check` and the
 // Prisma `where` are BOTH derived, with cached delegation (not a per-child
 // probe). Role kinds:
-//   match   — scalar equality on self (zero-query on a loaded row)
-//   where   — arbitrary Prisma filter (DB-evaluated)
+//   match     — scalar equality on self (zero-query on a loaded row)
+//   userMatch — like `match`, but only for an authenticated principal (auto-denies anonymous)
+//   where     — arbitrary Prisma filter (DB-evaluated)
+//   userWhere — like `where`, but only for an authenticated principal (auto-denies anonymous)
 //   via     — cached delegation to a parent policy's role
 //   hasRole — global/principal-role leaf, nestable
 //   authenticated — held if there is any logged-in principal
@@ -191,6 +194,32 @@ interface PredicateRole<TModelName extends ModelPropName> {
   kind: 'where';
   where: (ctx: ServiceContext) => WhereResult<TModelName>;
 }
+/**
+ * `r.userMatch` — like `r.match`, but the callback only runs for an
+ * authenticated principal (a `type: 'user'` session), receiving that session
+ * (`userId` guaranteed non-null) alongside `ctx`. Unauthenticated → deny,
+ * callback never invoked. Removes the per-callsite
+ * `ctx.auth.userId != null ? {...} : false` guard.
+ */
+interface UserMatchRole<TModelName extends ModelPropName> {
+  kind: 'userMatch';
+  userMatch: (
+    session: AuthUserSessionInfo,
+    ctx: ServiceContext,
+  ) => LocalMatch<TModelName> | false;
+}
+/**
+ * `r.userWhere` — like `r.where`, but the callback only runs for an
+ * authenticated principal (a `type: 'user'` session), receiving that session
+ * (`userId` guaranteed non-null) alongside `ctx`.
+ */
+interface UserWhereRole<TModelName extends ModelPropName> {
+  kind: 'userWhere';
+  userWhere: (
+    session: AuthUserSessionInfo,
+    ctx: ServiceContext,
+  ) => WhereResult<TModelName>;
+}
 /** `r.via` — delegate to a parent policy's role through a FK (cached checkById). */
 interface ViaRole<TModelName extends ModelPropName> {
   kind: 'via';
@@ -245,7 +274,9 @@ interface CheckRole<TModelName extends ModelPropName> {
  */
 type RoleNode<TModelName extends ModelPropName> =
   | MatchRole<TModelName>
+  | UserMatchRole<TModelName>
   | PredicateRole<TModelName>
+  | UserWhereRole<TModelName>
   | ViaRole<TModelName>
   | HasRoleLeaf
   | AuthenticatedLeaf
@@ -268,6 +299,28 @@ export interface RoleBuilder<TModelName extends ModelPropName> {
   where: (
     where: (ctx: ServiceContext) => WhereResult<TModelName>,
   ) => PredicateRole<TModelName>;
+  /**
+   * Authenticated scalar-equality fast path (zero-query). Callback only runs
+   * for a `type: 'user'` session — unauthenticated denies without calling it.
+   * See `UserMatchRole`.
+   */
+  userMatch: (
+    userMatch: (
+      session: AuthUserSessionInfo,
+      ctx: ServiceContext,
+    ) => LocalMatch<TModelName> | false,
+  ) => UserMatchRole<TModelName>;
+  /**
+   * Authenticated Prisma filter (DB-evaluated). Callback only runs for a
+   * `type: 'user'` session — unauthenticated denies without calling it. See
+   * `UserWhereRole`.
+   */
+  userWhere: (
+    userWhere: (
+      session: AuthUserSessionInfo,
+      ctx: ServiceContext,
+    ) => WhereResult<TModelName>,
+  ) => UserWhereRole<TModelName>;
   /**
    * Delegate to a parent policy's role through a FK (cached checkById). The
    * type checks `relation` is a to-one key and `fk` is a scalar of this model,
@@ -534,7 +587,9 @@ export function createModelPolicy<
 
   const builder: RoleBuilder<TModelName> = {
     match: (match) => ({ kind: 'match', match }),
+    userMatch: (userMatch) => ({ kind: 'userMatch', userMatch }),
     where: (where) => ({ kind: 'where', where }),
+    userWhere: (userWhere) => ({ kind: 'userWhere', userWhere }),
     via: (target, role, link) => ({
       kind: 'via',
       target,
@@ -598,7 +653,10 @@ export function createModelPolicy<
     parts: readonly RoleNode<TModelName>[],
   ): { node: RoleNode<TModelName>; i: number }[] {
     const cheap = (n: RoleNode<TModelName>): number =>
-      n.kind === 'match' || n.kind === 'hasRole' || n.kind === 'authenticated'
+      n.kind === 'match' ||
+      n.kind === 'userMatch' ||
+      n.kind === 'hasRole' ||
+      n.kind === 'authenticated'
         ? 0
         : 1;
     return parts
@@ -622,11 +680,26 @@ export function createModelPolicy<
         validateMatch(m, key);
         return m;
       }
+      case 'userMatch': {
+        // Deny BEFORE invoking the callback if unauthenticated — the callback's
+        // session is guaranteed `type: 'user'` (non-null `userId`).
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        const m = node.userMatch(session, ctx);
+        if (m === false) return false;
+        validateMatch(m, key);
+        return m;
+      }
       case 'via': {
         return node.target.roles[node.role].nestedWhere(ctx, node.relation);
       }
       case 'where': {
         return assertNotUndefined(node.where(ctx), key);
+      }
+      case 'userWhere': {
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        return assertNotUndefined(node.userWhere(session, ctx), key);
       }
       case 'hasRole': {
         // Held → unrestricted (`true` folds through queryHelpers); else `false`
@@ -674,6 +747,13 @@ export function createModelPolicy<
         if (m === false) return false;
         return evaluateMatch(m, model, key);
       }
+      case 'userMatch': {
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        const m = node.userMatch(session, ctx);
+        if (m === false) return false;
+        return evaluateMatch(m, model, key);
+      }
       case 'via': {
         // Delegation: parent's cached checkById, keyed on the PARENT id → N
         // children of one parent collapse to 1 query, even concurrently.
@@ -682,6 +762,17 @@ export function createModelPolicy<
       }
       case 'where': {
         const where = assertNotUndefined(node.where(ctx), key);
+        if (where === true) return true;
+        if (where === false) return false;
+        const id = String(model[config.idField]);
+        return cachedBoolean(ctx, roleCacheKey(id, key), () =>
+          exists(ctx, id, where),
+        );
+      }
+      case 'userWhere': {
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        const where = assertNotUndefined(node.userWhere(session, ctx), key);
         if (where === true) return true;
         if (where === false) return false;
         const id = String(model[config.idField]);

--- a/packages/fastify-generators/src/generators/auth/auth-plugin/extractor.json
+++ b/packages/fastify-generators/src/generators/auth/auth-plugin/extractor.json
@@ -6,13 +6,13 @@
       "fileOptions": { "kind": "singleton" },
       "generator": "@baseplate-dev/fastify-generators#auth/auth-plugin",
       "importMapProviders": {
-        "authContextImportsProvider": {
-          "importName": "authContextImportsProvider",
-          "packagePathSpecifier": "@baseplate-dev/fastify-generators:src/generators/auth/auth-context/generated/ts-import-providers.ts"
-        },
         "appModuleSetupImportsProvider": {
           "importName": "appModuleSetupImportsProvider",
           "packagePathSpecifier": "@baseplate-dev/fastify-generators:src/generators/core/app-module-setup/generated/ts-import-providers.ts"
+        },
+        "authContextImportsProvider": {
+          "importName": "authContextImportsProvider",
+          "packagePathSpecifier": "@baseplate-dev/fastify-generators:src/generators/auth/auth-context/generated/ts-import-providers.ts"
         }
       },
       "pathRootRelativePath": "{module-root}/plugins/auth.plugin.ts",

--- a/packages/fastify-generators/src/generators/core/app-runtime/extractor.json
+++ b/packages/fastify-generators/src/generators/core/app-runtime/extractor.json
@@ -15,10 +15,10 @@
       "sourceFile": "src/utils/app-runtime.ts",
       "variables": {
         "TPL_OPTIONS_PARAM": {},
-        "TPL_RUNTIME_FIELDS": {},
         "TPL_RUNTIME_FIELD_VALUES": {},
-        "TPL_SERVICES_OBJECT": {},
-        "TPL_SERVICE_CONSTRUCTION": {}
+        "TPL_RUNTIME_FIELDS": {},
+        "TPL_SERVICE_CONSTRUCTION": {},
+        "TPL_SERVICES_OBJECT": {}
       }
     },
     "runtime-services": {

--- a/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/extractor.json
+++ b/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/extractor.json
@@ -13,6 +13,10 @@
       "fileOptions": { "kind": "singleton" },
       "group": "main",
       "importMapProviders": {
+        "authContextImportsProvider": {
+          "importName": "authContextImportsProvider",
+          "packagePathSpecifier": "@baseplate-dev/fastify-generators:src/generators/auth/auth-context/generated/ts-import-providers.ts"
+        },
         "authRolesImportsProvider": {
           "importName": "authRolesImportsProvider",
           "packagePathSpecifier": "@baseplate-dev/fastify-generators:src/generators/auth/auth-roles/generated/ts-import-providers.ts"

--- a/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/generated/template-renderers.ts
+++ b/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/generated/template-renderers.ts
@@ -4,6 +4,7 @@ import type { BuilderAction } from '@baseplate-dev/sync';
 import { typescriptFileProvider } from '@baseplate-dev/core-generators';
 import { createGeneratorTask, createProviderType } from '@baseplate-dev/sync';
 
+import { authContextImportsProvider } from '#src/generators/auth/auth-context/generated/ts-import-providers.js';
 import { authRolesImportsProvider } from '#src/generators/auth/auth-roles/generated/ts-import-providers.js';
 import { errorHandlerServiceImportsProvider } from '#src/generators/core/error-handler-service/generated/ts-import-providers.js';
 import { serviceContextImportsProvider } from '#src/generators/core/service-context/generated/ts-import-providers.js';
@@ -34,6 +35,7 @@ const prismaPrismaAuthorizerUtilsRenderers =
 
 const prismaPrismaAuthorizerUtilsRenderersTask = createGeneratorTask({
   dependencies: {
+    authContextImports: authContextImportsProvider,
     authRolesImports: authRolesImportsProvider,
     dataUtilsImports: dataUtilsImportsProvider,
     errorHandlerServiceImports: errorHandlerServiceImportsProvider,
@@ -48,6 +50,7 @@ const prismaPrismaAuthorizerUtilsRenderersTask = createGeneratorTask({
       prismaPrismaAuthorizerUtilsRenderers.export(),
   },
   run({
+    authContextImports,
     authRolesImports,
     dataUtilsImports,
     errorHandlerServiceImports,
@@ -66,6 +69,7 @@ const prismaPrismaAuthorizerUtilsRenderersTask = createGeneratorTask({
                 group: PRISMA_PRISMA_AUTHORIZER_UTILS_TEMPLATES.mainGroup,
                 paths,
                 importMapProviders: {
+                  authContextImports,
                   authRolesImports,
                   dataUtilsImports,
                   errorHandlerServiceImports,

--- a/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/generated/typed-templates.ts
+++ b/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/generated/typed-templates.ts
@@ -1,6 +1,7 @@
 import { createTsTemplateFile } from '@baseplate-dev/core-generators';
 import path from 'node:path';
 
+import { authContextImportsProvider } from '#src/generators/auth/auth-context/generated/ts-import-providers.js';
 import { authRolesImportsProvider } from '#src/generators/auth/auth-roles/generated/ts-import-providers.js';
 import { errorHandlerServiceImportsProvider } from '#src/generators/core/error-handler-service/generated/ts-import-providers.js';
 import { serviceContextImportsProvider } from '#src/generators/core/service-context/generated/ts-import-providers.js';
@@ -12,6 +13,7 @@ const utilsAuthorizers = createTsTemplateFile({
   fileOptions: { kind: 'singleton' },
   group: 'main',
   importMapProviders: {
+    authContextImports: authContextImportsProvider,
     authRolesImports: authRolesImportsProvider,
     dataUtilsImports: dataUtilsImportsProvider,
     errorHandlerServiceImports: errorHandlerServiceImportsProvider,

--- a/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/templates/src/utils/authorizers.ts
+++ b/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/templates/src/utils/authorizers.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+import type { AuthUserSessionInfo } from '%authContextImports';
 import type { AuthRole } from '%authRolesImports';
 import type {
   GetResult,
@@ -119,8 +120,10 @@ interface ViaLink<M extends ModelPropName, R extends ToOneRelationKeys<M>> {
 // createModelPolicy — one declaration per role; the boolean `check` and the
 // Prisma `where` are BOTH derived, with cached delegation (not a per-child
 // probe). Role kinds:
-//   match   — scalar equality on self (zero-query on a loaded row)
-//   where   — arbitrary Prisma filter (DB-evaluated)
+//   match     — scalar equality on self (zero-query on a loaded row)
+//   userMatch — like `match`, but only for an authenticated principal (auto-denies anonymous)
+//   where     — arbitrary Prisma filter (DB-evaluated)
+//   userWhere — like `where`, but only for an authenticated principal (auto-denies anonymous)
 //   via     — cached delegation to a parent policy's role
 //   hasRole — global/principal-role leaf, nestable
 //   authenticated — held if there is any logged-in principal
@@ -193,6 +196,32 @@ interface PredicateRole<TModelName extends ModelPropName> {
   kind: 'where';
   where: (ctx: ServiceContext) => WhereResult<TModelName>;
 }
+/**
+ * `r.userMatch` — like `r.match`, but the callback only runs for an
+ * authenticated principal (a `type: 'user'` session), receiving that session
+ * (`userId` guaranteed non-null) alongside `ctx`. Unauthenticated → deny,
+ * callback never invoked. Removes the per-callsite
+ * `ctx.auth.userId != null ? {...} : false` guard.
+ */
+interface UserMatchRole<TModelName extends ModelPropName> {
+  kind: 'userMatch';
+  userMatch: (
+    session: AuthUserSessionInfo,
+    ctx: ServiceContext,
+  ) => LocalMatch<TModelName> | false;
+}
+/**
+ * `r.userWhere` — like `r.where`, but the callback only runs for an
+ * authenticated principal (a `type: 'user'` session), receiving that session
+ * (`userId` guaranteed non-null) alongside `ctx`.
+ */
+interface UserWhereRole<TModelName extends ModelPropName> {
+  kind: 'userWhere';
+  userWhere: (
+    session: AuthUserSessionInfo,
+    ctx: ServiceContext,
+  ) => WhereResult<TModelName>;
+}
 /** `r.via` — delegate to a parent policy's role through a FK (cached checkById). */
 interface ViaRole<TModelName extends ModelPropName> {
   kind: 'via';
@@ -247,7 +276,9 @@ interface CheckRole<TModelName extends ModelPropName> {
  */
 type RoleNode<TModelName extends ModelPropName> =
   | MatchRole<TModelName>
+  | UserMatchRole<TModelName>
   | PredicateRole<TModelName>
+  | UserWhereRole<TModelName>
   | ViaRole<TModelName>
   | HasRoleLeaf
   | AuthenticatedLeaf
@@ -270,6 +301,28 @@ export interface RoleBuilder<TModelName extends ModelPropName> {
   where: (
     where: (ctx: ServiceContext) => WhereResult<TModelName>,
   ) => PredicateRole<TModelName>;
+  /**
+   * Authenticated scalar-equality fast path (zero-query). Callback only runs
+   * for a `type: 'user'` session — unauthenticated denies without calling it.
+   * See `UserMatchRole`.
+   */
+  userMatch: (
+    userMatch: (
+      session: AuthUserSessionInfo,
+      ctx: ServiceContext,
+    ) => LocalMatch<TModelName> | false,
+  ) => UserMatchRole<TModelName>;
+  /**
+   * Authenticated Prisma filter (DB-evaluated). Callback only runs for a
+   * `type: 'user'` session — unauthenticated denies without calling it. See
+   * `UserWhereRole`.
+   */
+  userWhere: (
+    userWhere: (
+      session: AuthUserSessionInfo,
+      ctx: ServiceContext,
+    ) => WhereResult<TModelName>,
+  ) => UserWhereRole<TModelName>;
   /**
    * Delegate to a parent policy's role through a FK (cached checkById). The
    * type checks `relation` is a to-one key and `fk` is a scalar of this model,
@@ -536,7 +589,9 @@ export function createModelPolicy<
 
   const builder: RoleBuilder<TModelName> = {
     match: (match) => ({ kind: 'match', match }),
+    userMatch: (userMatch) => ({ kind: 'userMatch', userMatch }),
     where: (where) => ({ kind: 'where', where }),
+    userWhere: (userWhere) => ({ kind: 'userWhere', userWhere }),
     via: (target, role, link) => ({
       kind: 'via',
       target,
@@ -600,7 +655,10 @@ export function createModelPolicy<
     parts: readonly RoleNode<TModelName>[],
   ): { node: RoleNode<TModelName>; i: number }[] {
     const cheap = (n: RoleNode<TModelName>): number =>
-      n.kind === 'match' || n.kind === 'hasRole' || n.kind === 'authenticated'
+      n.kind === 'match' ||
+      n.kind === 'userMatch' ||
+      n.kind === 'hasRole' ||
+      n.kind === 'authenticated'
         ? 0
         : 1;
     return parts
@@ -624,11 +682,26 @@ export function createModelPolicy<
         validateMatch(m, key);
         return m;
       }
+      case 'userMatch': {
+        // Deny BEFORE invoking the callback if unauthenticated — the callback's
+        // session is guaranteed `type: 'user'` (non-null `userId`).
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        const m = node.userMatch(session, ctx);
+        if (m === false) return false;
+        validateMatch(m, key);
+        return m;
+      }
       case 'via': {
         return node.target.roles[node.role].nestedWhere(ctx, node.relation);
       }
       case 'where': {
         return assertNotUndefined(node.where(ctx), key);
+      }
+      case 'userWhere': {
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        return assertNotUndefined(node.userWhere(session, ctx), key);
       }
       case 'hasRole': {
         // Held → unrestricted (`true` folds through queryHelpers); else `false`
@@ -676,6 +749,13 @@ export function createModelPolicy<
         if (m === false) return false;
         return evaluateMatch(m, model, key);
       }
+      case 'userMatch': {
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        const m = node.userMatch(session, ctx);
+        if (m === false) return false;
+        return evaluateMatch(m, model, key);
+      }
       case 'via': {
         // Delegation: parent's cached checkById, keyed on the PARENT id → N
         // children of one parent collapse to 1 query, even concurrently.
@@ -684,6 +764,17 @@ export function createModelPolicy<
       }
       case 'where': {
         const where = assertNotUndefined(node.where(ctx), key);
+        if (where === true) return true;
+        if (where === false) return false;
+        const id = String(model[config.idField]);
+        return cachedBoolean(ctx, roleCacheKey(id, key), () =>
+          exists(ctx, id, where),
+        );
+      }
+      case 'userWhere': {
+        const { session } = ctx.auth;
+        if (session?.type !== 'user') return false;
+        const where = assertNotUndefined(node.userWhere(session, ctx), key);
         if (where === true) return true;
         if (where === false) return false;
         const id = String(model[config.idField]);

--- a/packages/project-builder-server/src/compiler/backend/authorizer-expression-codegen-utils.ts
+++ b/packages/project-builder-server/src/compiler/backend/authorizer-expression-codegen-utils.ts
@@ -45,3 +45,31 @@ export function generateFieldRefOrLiteralCode(
   }
   return `ctx.auth.${node.field}`;
 }
+
+/** An auth-field ref whose non-null form is guaranteed once authenticated. */
+export function isGuaranteedAuthField(
+  node: FieldRefNode | LiteralValueNode,
+): boolean {
+  return (
+    node.type === 'fieldRef' &&
+    node.source === 'auth' &&
+    node.field === 'userId'
+  );
+}
+
+/**
+ * Like {@link generateFieldRefOrLiteralCode}, but auth refs render as
+ * `session.field` (the `r.userMatch`/`r.userWhere` callback param — a
+ * guaranteed-authenticated session) instead of `ctx.auth.field`.
+ */
+export function generateFieldRefOrLiteralCodeForSession(
+  node: FieldRefNode | LiteralValueNode,
+): string {
+  if (node.type === 'literalValue') {
+    return serializeLiteralValue(node.value);
+  }
+  if (node.source === 'model') {
+    return `model.${node.field}`;
+  }
+  return `session.${node.field}`;
+}

--- a/packages/project-builder-server/src/compiler/backend/policy-lowering.ts
+++ b/packages/project-builder-server/src/compiler/backend/policy-lowering.ts
@@ -32,8 +32,15 @@ import { quot } from '@baseplate-dev/utils';
 
 import type { QueryFilterCodeContext } from './query-filter-codegen.js';
 
-import { generateFieldRefOrLiteralCode } from './authorizer-expression-codegen-utils.js';
-import { generateQueryFilterExpressionCode } from './query-filter-codegen.js';
+import {
+  generateFieldRefOrLiteralCode,
+  generateFieldRefOrLiteralCodeForSession,
+  isGuaranteedAuthField,
+} from './authorizer-expression-codegen-utils.js';
+import {
+  generateQueryFilterExpressionCode,
+  referencesOnlyGuaranteedAuthField,
+} from './query-filter-codegen.js';
 
 /**
  * A resolved to-one delegation link (parent policy + FK/relation), for `r.via`.
@@ -77,13 +84,19 @@ function isMatchable(node: AuthorizerExpressionNode): boolean {
 }
 
 /**
- * Render the `{ field: value }` object body for a matchable comparison. If the
- * value is an auth field, guard it (`ctx.auth.x != null ? {...} : false`) so an
- * unauthenticated principal denies rather than matching everything.
+ * Render a matchable comparison as an `r.match`/`r.userMatch` builder call
+ * (the callback + verb together, since the two forms take different params).
+ *
+ * - Auth field is `userId` (non-null guaranteed once authenticated) →
+ *   `r.userMatch((session) => ({...}))`, no null-guard needed.
+ * - Auth field is anything else (no non-null guarantee) →
+ *   `r.match((ctx) => (ctx.auth.x != null ? {...} : false))`, guarded so an
+ *   unauthenticated principal denies rather than matching everything.
+ * - Literal value → `r.match(() => ({...}))`, unguarded.
  */
-function renderMatchBody(node: AuthorizerExpressionNode): string {
+function renderMatchCall(node: AuthorizerExpressionNode): string {
   if (node.type !== 'fieldComparison') {
-    throw new Error('renderMatchBody called on non-comparison node');
+    throw new Error('renderMatchCall called on non-comparison node');
   }
   const modelSide = ([node.left, node.right] as (typeof node.left)[]).find(
     (s): s is FieldRefNode => s.type === 'fieldRef' && s.source === 'model',
@@ -93,14 +106,21 @@ function renderMatchBody(node: AuthorizerExpressionNode): string {
     throw new Error('matchable comparison missing model field');
   }
   const { field } = modelSide;
+
+  if (isGuaranteedAuthField(otherSide)) {
+    const value = generateFieldRefOrLiteralCodeForSession(otherSide);
+    return `r.userMatch((session) => ({ ${field}: ${value} }))`;
+  }
+
   const value = generateFieldRefOrLiteralCode(otherSide);
   const objectBody = `{ ${field}: ${value} }`;
 
-  // Auth-field value → null-guard so unauthenticated denies (never match-all).
+  // Auth-field value (no non-null guarantee) → null-guard so unauthenticated
+  // denies (never match-all).
   if (otherSide.type === 'fieldRef' && otherSide.source === 'auth') {
-    return `(ctx) => (ctx.auth.${otherSide.field} != null ? ${objectBody} : false)`;
+    return `r.match((ctx) => (ctx.auth.${otherSide.field} != null ? ${objectBody} : false))`;
   }
-  return `() => (${objectBody})`;
+  return `r.match(() => (${objectBody}))`;
 }
 
 /**
@@ -120,24 +140,32 @@ function renderVia(link: ResolvedViaLink, role: string): string {
 function createPolicyLoweringVisitor(
   ctx: PolicyLoweringContext,
 ): AuthorizerExpressionVisitor<string> {
-  /** Fallback: lower any node to `r.where` using the query-filter codegen. */
+  /**
+   * Fallback: lower any node to `r.where`/`r.userWhere` using the query-filter
+   * codegen. `r.userWhere` applies when the node references `auth.userId` and
+   * no other auth field — its non-null guarantee lets the null-check collapse.
+   */
   const asWhere = (node: AuthorizerExpressionNode): string => {
+    const useUserPrincipal = referencesOnlyGuaranteedAuthField(node);
     const whereBody = generateQueryFilterExpressionCode(
       node,
       ctx.queryFilterContext,
+      { forSession: useUserPrincipal },
     );
     // The query-filter body is a `where`-returning expression; a leading `{`
     // needs parens to be a valid arrow body.
     const wrapped = whereBody.trimStart().startsWith('{')
       ? `(${whereBody})`
       : whereBody;
-    return `r.where((ctx) => ${wrapped})`;
+    return useUserPrincipal
+      ? `r.userWhere((session) => ${wrapped})`
+      : `r.where((ctx) => ${wrapped})`;
   };
 
   return {
     fieldComparison(node) {
       if (isMatchable(node)) {
-        return `r.match(${renderMatchBody(node)})`;
+        return renderMatchCall(node);
       }
       // `!==` (or model-vs-model) → where fallback.
       return asWhere(node);

--- a/packages/project-builder-server/src/compiler/backend/policy-lowering.unit.test.ts
+++ b/packages/project-builder-server/src/compiler/backend/policy-lowering.unit.test.ts
@@ -30,9 +30,9 @@ function lower(
 
 describe('lowerExpressionToRoleTree', () => {
   describe('r.match — scalar equality (===)', () => {
-    it('auth field → null-guarded match', () => {
+    it('auth field userId → r.userMatch (no null-guard, guaranteed non-null)', () => {
       expect(lower('model.publisherId === userId')).toBe(
-        'r.match((ctx) => (ctx.auth.userId != null ? { publisherId: ctx.auth.userId } : false))',
+        'r.userMatch((session) => ({ publisherId: session.userId }))',
       );
     });
 
@@ -65,9 +65,9 @@ describe('lowerExpressionToRoleTree', () => {
       );
     });
 
-    it('!== against auth field falls back to r.where (null-guarded)', () => {
+    it('!== against auth field userId falls back to r.userWhere (no null-guard)', () => {
       expect(lower('model.id !== userId')).toBe(
-        'r.where((ctx) => (ctx.auth.userId != null ? { id: { not: ctx.auth.userId } } : false))',
+        'r.userWhere((session) => ({ id: { not: session.userId } }))',
       );
     });
   });
@@ -116,7 +116,7 @@ describe('lowerExpressionToRoleTree', () => {
 
     it('|| → r.some', () => {
       expect(lower("model.publisherId === userId || hasRole('admin')")).toBe(
-        "r.some([r.match((ctx) => (ctx.auth.userId != null ? { publisherId: ctx.auth.userId } : false)), r.hasRole('admin')])",
+        "r.some([r.userMatch((session) => ({ publisherId: session.userId })), r.hasRole('admin')])",
       );
     });
 
@@ -142,11 +142,22 @@ describe('lowerExpressionToRoleTree', () => {
   });
 
   describe('r.where — relation membership fallback', () => {
-    it('exists(...) → r.where with { some }', () => {
-      // The where-body already starts with `(` (the null-guard ternary), so the
-      // asWhere wrapper does not add redundant parens.
+    it('exists(...) referencing only userId → r.userWhere (no null-guard)', () => {
       expect(lower('exists(model.members, { userId: userId })')).toBe(
-        'r.where((ctx) => (ctx.auth.userId != null ? { members: { some: { userId: ctx.auth.userId } } } : false))',
+        'r.userWhere((session) => ({ members: { some: { userId: session.userId } } }))',
+      );
+    });
+  });
+
+  describe('r.userMatch / r.userWhere — composition', () => {
+    it('r.userMatch composes inside r.some with r.via', () => {
+      expect(
+        lower(
+          "model.ownerId === userId || hasRole(model.blog, 'owner')",
+          ctxWith({ blog: VIA_BLOG }),
+        ),
+      ).toBe(
+        "r.some([r.userMatch((session) => ({ ownerId: session.userId })), r.via(blogPolicy, 'owner', { fk: 'blogId', relation: 'blog' })])",
       );
     });
   });

--- a/packages/project-builder-server/src/compiler/backend/query-filter-codegen.ts
+++ b/packages/project-builder-server/src/compiler/backend/query-filter-codegen.ts
@@ -22,6 +22,8 @@ import { quot } from '@baseplate-dev/utils';
 
 import {
   generateFieldRefOrLiteralCode,
+  generateFieldRefOrLiteralCodeForSession,
+  isGuaranteedAuthField,
   serializeLiteralValue,
 } from './authorizer-expression-codegen-utils.js';
 
@@ -41,6 +43,47 @@ export interface QueryFilterCodeContext {
   resolvedFilters: Map<string, ResolvedNestedQueryFilter>;
 }
 
+/** Options for {@link generateQueryFilterExpressionCode}. */
+export interface QueryFilterCodeOptions {
+  /**
+   * Render for the `r.userWhere` callback (`session.field`, no null-guard)
+   * instead of `r.where` (`ctx.auth.field`, null-guarded). Only valid when the
+   * node references `auth.userId` and no other auth field — callers must
+   * check {@link referencesOnlyGuaranteedAuthField} first.
+   */
+  forSession?: boolean;
+}
+
+/**
+ * Does this leaf node (a `fieldComparison` or `relationFilter` — the only
+ * shapes the policy lowering's `asWhere` fallback receives) reference
+ * `auth.userId` and no other auth field? If so, its null-guard collapses
+ * under `r.userWhere`'s non-null guarantee.
+ */
+export function referencesOnlyGuaranteedAuthField(
+  node: AuthorizerExpressionNode,
+): boolean {
+  const authFieldRefs: (FieldRefNode | LiteralValueNode)[] = [];
+  if (node.type === 'fieldComparison') {
+    if (node.left.type === 'fieldRef' && node.left.source === 'auth') {
+      authFieldRefs.push(node.left);
+    }
+    if (node.right.type === 'fieldRef' && node.right.source === 'auth') {
+      authFieldRefs.push(node.right);
+    }
+  } else if (node.type === 'relationFilter') {
+    for (const condition of node.conditions) {
+      if (
+        condition.value.type === 'fieldRef' &&
+        condition.value.source === 'auth'
+      ) {
+        authFieldRefs.push(condition.value);
+      }
+    }
+  }
+  return authFieldRefs.length > 0 && authFieldRefs.every(isGuaranteedAuthField);
+}
+
 /**
  * Build a visitor that emits Prisma where-clause code from AST nodes.
  *
@@ -51,6 +94,7 @@ export interface QueryFilterCodeContext {
  */
 function createQueryFilterCodeVisitor(
   codeContext?: QueryFilterCodeContext,
+  options?: QueryFilterCodeOptions,
 ): AuthorizerExpressionVisitor<string> {
   return {
     fieldComparison(node) {
@@ -58,6 +102,7 @@ function createQueryFilterCodeVisitor(
         node.left,
         node.right,
         node.operator,
+        options,
       );
     },
     hasRole(node) {
@@ -84,7 +129,7 @@ function createQueryFilterCodeVisitor(
       )}, [${roles}])`;
     },
     relationFilter(node) {
-      return generateRelationFilterWhereCode(node);
+      return generateRelationFilterWhereCode(node, options);
     },
     binaryLogical(node, _ctx, visit) {
       const helper = node.operator === '||' ? 'or' : 'and';
@@ -101,10 +146,11 @@ function createQueryFilterCodeVisitor(
 export function generateQueryFilterExpressionCode(
   node: AuthorizerExpressionNode,
   codeContext?: QueryFilterCodeContext,
+  options?: QueryFilterCodeOptions,
 ): string {
   return visitAuthorizerExpression(
     node,
-    createQueryFilterCodeVisitor(codeContext),
+    createQueryFilterCodeVisitor(codeContext, options),
   );
 }
 
@@ -145,20 +191,30 @@ function getResolvedQueryFilter(
 
 /**
  * Prisma where for a relation filter: `some` → `{ rel: { some: {...} } }`,
- * `every` → `{ rel: { every: {...} } }`. Auth-field conditions get a null guard.
+ * `every` → `{ rel: { every: {...} } }`. Auth-field conditions get a null
+ * guard, UNLESS `forSession` (every auth field in the filter is `userId`,
+ * guaranteed non-null by `r.userWhere` — see `referencesOnlyGuaranteedAuthField`).
  */
 function generateRelationFilterWhereCode(
   node: Extract<AuthorizerExpressionNode, { type: 'relationFilter' }>,
+  options?: QueryFilterCodeOptions,
 ): string {
   const prismaOperator = node.operator === 'some' ? 'some' : 'every';
+  const renderValue = options?.forSession
+    ? generateFieldRefOrLiteralCodeForSession
+    : generateFieldRefOrLiteralCode;
 
   const conditionEntries = node.conditions.map((condition) => {
-    const valueCode = generateFieldRefOrLiteralCode(condition.value);
+    const valueCode = renderValue(condition.value);
     return `${condition.field}: ${valueCode}`;
   });
   const conditionsCode = conditionEntries.join(', ');
 
   const whereClause = `{ ${node.relationName}: { ${prismaOperator}: { ${conditionsCode} } } }`;
+
+  if (options?.forSession) {
+    return whereClause;
+  }
 
   const authFieldConditions = node.conditions.filter(
     (c) => c.value.type === 'fieldRef' && c.value.source === 'auth',
@@ -180,11 +236,14 @@ function generateRelationFilterWhereCode(
  * - `model.field !== literal` → `{ field: { not: literal } }`
  * - `model.field === auth.x`  → `(ctx.auth.x != null ? { field: ctx.auth.x } : false)`
  * - `model.field !== auth.x`  → `(ctx.auth.x != null ? { field: { not: ctx.auth.x } } : false)`
+ * - `forSession` (auth.x is `userId`, guaranteed non-null by `r.userWhere`):
+ *   `model.field === userId` → `{ field: session.userId }` (no null-guard)
  */
 function generateFieldComparisonWhereCode(
   left: FieldRefNode | LiteralValueNode,
   right: FieldRefNode | LiteralValueNode,
   operator: '===' | '!==',
+  options?: QueryFilterCodeOptions,
 ): string {
   const modelNode =
     left.type === 'fieldRef' && left.source === 'model'
@@ -214,6 +273,15 @@ function generateFieldComparisonWhereCode(
       'Field comparison must compare a model field against an auth field or a literal value.',
     );
   }
+
+  if (options?.forSession) {
+    const sessionExpr = generateFieldRefOrLiteralCodeForSession(otherNode);
+    if (operator === '!==') {
+      return `{ ${modelNode.field}: { not: ${sessionExpr} } }`;
+    }
+    return `{ ${modelNode.field}: ${sessionExpr} }`;
+  }
+
   const authExpr = `ctx.auth.${otherNode.field}`;
   if (operator === '!==') {
     return `(${authExpr} != null ? { ${modelNode.field}: { not: ${authExpr} } } : false)`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated-user role helpers for matching records and filtering related data.
  * Authorization policies now use the signed-in user’s session directly for ownership and membership checks.
  * Anonymous requests are automatically denied for user-specific authorization rules.

* **Bug Fixes**
  * Improved generated authorization policies by removing unnecessary authentication checks and simplifying user-based permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->