### PR TITLE
refactor: Put notification types into the app module instead of a central registry

### DIFF
--- a/.changeset/notification-types-app-module.md
+++ b/.changeset/notification-types-app-module.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/plugin-notifications': patch
+---
+
+Notification types are now declared through `AppModule.notificationTypes` and collected into a per-runtime registry when the app runtime is constructed, instead of registering themselves as an import side effect into a module-level global.

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/notifications/index.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/notifications/index.ts
@@ -1,5 +1,7 @@
 import { defineAppModule } from '@src/utils/app-modules.js';
 
+import { GENERIC_NOTIFICATION_TYPE } from './services/generic-type.js';
+
 /* TPL_IMPORTS:START */
 import './schema/notification-content.field.js';
 import './schema/notification-content.object-types.js';
@@ -7,10 +9,11 @@ import './schema/notification.mutations.js';
 import './schema/notification.object-type.js';
 import './schema/notification.queries.js';
 import './schema/notification.subscriptions.js';
-import './services/generic-type.js';
 /* TPL_IMPORTS:END */
 
 export const /* TPL_MODULE_NAME:START */ notificationsModule /* TPL_MODULE_NAME:END */ =
     defineAppModule(
-      /* TPL_MODULE_CONTENTS:START */ {} /* TPL_MODULE_CONTENTS:END */,
+      /* TPL_MODULE_CONTENTS:START */ {
+        notificationTypes: [GENERIC_NOTIFICATION_TYPE],
+      } /* TPL_MODULE_CONTENTS:END */,
     );

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/notifications/schema/notification-content.field.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/notifications/schema/notification-content.field.ts
@@ -1,17 +1,14 @@
 import { builder } from '@src/plugins/graphql/builder.js';
 
-import {
-  RENDER_SOURCE_SELECT,
-  renderContent,
-} from '../services/notification.service.js';
+import { RENDER_SOURCE_SELECT } from '../services/notification.service.js';
 import { notificationContentType } from './notification-content.object-types.js';
 import { notificationObjectType } from './notification.object-type.js';
 
 /**
- * The render-at-read site: `renderContent` re-renders from the stored source
- * (`params`) using the renderer that CREATED the row — pinned by
- * `(type, templateVersion)` — falling back to the frozen snapshot on a retired
- * renderer or param drift.
+ * The render-at-read site: `services.notifications.renderContent` re-renders
+ * from the stored source (`params`) using the renderer that CREATED the row —
+ * pinned by `(type, templateVersion)` — falling back to the frozen snapshot on
+ * a retired renderer or param drift.
  *
  * `locale` is an explicit ARG, not request context: Apollo keys its cache by
  * field args, so a language switch produces a separate cache entry instead of
@@ -27,8 +24,8 @@ builder.prismaObjectFields(
       type: notificationContentType,
       args: { locale: t.arg.string({ required: true, defaultValue: 'en' }) },
       select: RENDER_SOURCE_SELECT,
-      resolve: (notification, { locale }) =>
-        renderContent(notification, { locale }),
+      resolve: (notification, { locale }, ctx) =>
+        ctx.services.notifications.renderContent(notification, { locale }),
     }),
   }),
 );

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/notifications/services/notification-registry.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/notifications/services/notification-registry.ts
@@ -43,36 +43,20 @@ export interface NotificationTypeDefinition<
   paramsSchema: z.ZodType<P>;
   /** Eligible delivery channels, checked against the static channel dictionary. */
   channels: readonly NotificationChannelKey[];
-  /** Render content from a batch of events, in `ctx.locale`. */
-  render: (
+  /**
+   * Render content from a batch of events, in `ctx.locale`.
+   */
+  render(
     events: NotificationEvent<P>[],
     ctx: RenderContext,
-  ) => NotificationContent;
+  ): NotificationContent;
 }
 
-/** Registry key: a row's renderer is pinned by BOTH its type and its version. */
-function registryKey(key: string, version: number): string {
-  return `${key}@${version}`;
-}
-
-const registry = new Map<string, NotificationTypeDefinition>();
-
-/** Register a notification type version (call at module load). */
+/**
+ * Declares a notification type.
+ */
 export function defineNotificationType<P extends NotificationParams>(
   definition: NotificationTypeDefinition<P>,
 ): NotificationTypeDefinition<P> {
-  const id = registryKey(definition.key, definition.version);
-  if (registry.has(id)) {
-    throw new Error(`Notification type "${id}" is already defined`);
-  }
-  registry.set(id, definition as unknown as NotificationTypeDefinition);
   return definition;
-}
-
-/** Look up the renderer that a row was created with. */
-export function getNotificationType(
-  key: string,
-  version: number,
-): NotificationTypeDefinition | undefined {
-  return registry.get(registryKey(key, version));
 }

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/notifications/services/notification.service.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/notifications/services/notification.service.ts
@@ -26,7 +26,6 @@ import {
   segmentsToText,
   toSegments,
 } from './notification-content.js';
-import { getNotificationType } from './notification-registry.js';
 
 /** Default render locale until i18n lands. */
 const DEFAULT_LOCALE = 'en';
@@ -64,62 +63,9 @@ function frozenContent(row: RenderSource): RenderedContent {
   };
 }
 
-/**
- * Render a row's content at read time, ATOMICALLY: segments, fallbackText and
- * actionUrl all come from a single invocation of the renderer that CREATED the
- * row — resolved by `(type, templateVersion)`, never "whatever is deployed now".
- * A copy/param refactor bumps the version, so history can't be silently rewritten.
- *
- * Falls back to the frozen snapshot (and logs) when the pinned renderer is gone
- * or the stored params no longer satisfy it.
- */
-export function renderContent(
-  row: RenderSource,
-  ctx?: RenderContext,
-): RenderedContent {
-  const type = getNotificationType(row.type, row.templateVersion);
-  if (!type) {
-    logError(
-      new Error(
-        `No renderer for notification "${row.type}@${row.templateVersion}"`,
-      ),
-      { source: 'notification-render', notificationId: row.id },
-    );
-    return frozenContent(row);
-  }
-
-  const params = type.paramsSchema.safeParse(row.params ?? {});
-  if (!params.success) {
-    logError(params.error, {
-      source: 'notification-render',
-      reason: 'params-drift',
-      notificationId: row.id,
-      type: `${row.type}@${row.templateVersion}`,
-    });
-    return frozenContent(row);
-  }
-
-  const event: NotificationEvent = {
-    recipientId: '', // not needed to render the body
-    params: params.data,
-    actorId: row.actorId ?? undefined,
-    entityType: row.entityType ?? undefined,
-    entityId: row.entityId ?? undefined,
-  };
-
-  try {
-    return toRenderedContent(
-      type.render([event], ctx ?? { locale: DEFAULT_LOCALE }),
-    );
-  } catch (error) {
-    logError(error, {
-      source: 'notification-render',
-      reason: 'render-threw',
-      notificationId: row.id,
-      type: `${row.type}@${row.templateVersion}`,
-    });
-    return frozenContent(row);
-  }
+/** Registry key: a row's renderer is pinned by BOTH its type and its version. */
+function registryKey(key: string, version: number): string {
+  return `${key}@${version}`;
 }
 
 /** Project a renderer's output into the served content (one render, all fields). */
@@ -202,6 +148,16 @@ export interface NotificationService {
     options?: NotifyTextOptions,
   ): Promise<Notification>;
   /**
+   * Render a row's content at read time, ATOMICALLY: segments, fallbackText and
+   * actionUrl all come from a single invocation of the renderer that CREATED
+   * the row — resolved by `(type, templateVersion)` against the per-runtime
+   * registry, never "whatever is deployed now". A copy/param refactor bumps the
+   * version, so history can't be silently rewritten. Falls back to the frozen
+   * snapshot (and logs) when the pinned renderer is gone or params no longer
+   * satisfy it.
+   */
+  renderContent(row: RenderSource, ctx?: RenderContext): RenderedContent;
+  /**
    * Count of UNSEEN notifications — the bell badge. Seen (opening the panel)
    * clears the badge; read (clicking one) clears its highlight. `readAt`
    * always implies `seenAt` (see the read mutations), so this never counts a
@@ -244,9 +200,73 @@ async function getUnseenCount(userId: string): Promise<number> {
  */
 export function createNotificationService(deps: {
   events: NotificationEvents;
+  notificationTypes: NotificationTypeDefinition[];
 }): NotificationService {
-  const { events } = deps;
+  const { events, notificationTypes } = deps;
   const channels = createChannels({ events });
+
+  // Per-runtime registry: collected from `AppModule.notificationTypes` at
+  // construction. Duplicate `(key, version)` pairs fail HERE — deterministically
+  // at runtime construction — instead of at whatever import happened to load a
+  // colliding definition first.
+  const registry = new Map<string, NotificationTypeDefinition>();
+  for (const type of notificationTypes) {
+    const id = registryKey(type.key, type.version);
+    if (registry.has(id)) {
+      throw new Error(`Notification type "${id}" is already defined`);
+    }
+    registry.set(id, type);
+  }
+
+  /** Render a row's content at read time; see {@link NotificationService.renderContent}. */
+  function renderContent(
+    row: RenderSource,
+    ctx?: RenderContext,
+  ): RenderedContent {
+    const type = registry.get(registryKey(row.type, row.templateVersion));
+    if (!type) {
+      logError(
+        new Error(
+          `No renderer for notification "${row.type}@${row.templateVersion}"`,
+        ),
+        { source: 'notification-render', notificationId: row.id },
+      );
+      return frozenContent(row);
+    }
+
+    const params = type.paramsSchema.safeParse(row.params ?? {});
+    if (!params.success) {
+      logError(params.error, {
+        source: 'notification-render',
+        reason: 'params-drift',
+        notificationId: row.id,
+        type: `${row.type}@${row.templateVersion}`,
+      });
+      return frozenContent(row);
+    }
+
+    const event: NotificationEvent = {
+      recipientId: '', // not needed to render the body
+      params: params.data,
+      actorId: row.actorId ?? undefined,
+      entityType: row.entityType ?? undefined,
+      entityId: row.entityId ?? undefined,
+    };
+
+    try {
+      return toRenderedContent(
+        type.render([event], ctx ?? { locale: DEFAULT_LOCALE }),
+      );
+    } catch (error) {
+      logError(error, {
+        source: 'notification-render',
+        reason: 'render-threw',
+        notificationId: row.id,
+        type: `${row.type}@${row.templateVersion}`,
+      });
+      return frozenContent(row);
+    }
+  }
 
   /** Deliver to each of the type's channels; a channel that throws is logged, not rethrown. */
   async function dispatchToChannels(
@@ -417,6 +437,7 @@ export function createNotificationService(deps: {
   return {
     notify,
     notifyText,
+    renderContent,
     getUnseenCount,
     markAsRead,
     markAllAsSeen,

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/utils/app-modules.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/utils/app-modules.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync, FastifyPluginCallback } from 'fastify';
 
+import type { NotificationTypeDefinition } from '../modules/notifications/services/notification-registry.js';
 import type { QueueHandlerBinding } from '../types/queue.types.js';
 import type { AppServices } from './runtime-services.js';
 
@@ -37,6 +38,7 @@ export type AppPlugin =
 export interface AppModule {
   children?: AppModule[];
   /* TPL_MODULE_FIELDS:START */
+  notificationTypes?: NotificationTypeDefinition[];
   plugins?: AppPlugin[];
   queues?: QueueHandlerBinding[];
   /* TPL_MODULE_FIELDS:END */
@@ -68,12 +70,14 @@ export function flattenAppModule(
   const flattenedChildren = children.map(flattenAppModule);
 
   const result = /* TPL_MODULE_INITIALIZER:START */ {
+    notificationTypes: [...(rootModule.notificationTypes ?? [])],
     plugins: [...(rootModule.plugins ?? [])],
     queues: [...(rootModule.queues ?? [])],
   }; /* TPL_MODULE_INITIALIZER:END */
 
   for (const child of flattenedChildren) {
     /* TPL_MODULE_MERGER:START */
+    result.notificationTypes.push(...(child.notificationTypes ?? []));
     result.plugins.push(...(child.plugins ?? []));
     result.queues.push(...(child.queues ?? []));
     /* TPL_MODULE_MERGER:END */

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/utils/app-runtime.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/utils/app-runtime.ts
@@ -53,7 +53,8 @@ export function createAppRuntime(
   let disposePromise: Promise<void> | undefined;
 
   /* TPL_SERVICE_CONSTRUCTION:START */
-  const { queues: queueBindings = [] } = flattenAppModule(rootModule);
+  const { notificationTypes = [], queues: queueBindings = [] } =
+    flattenAppModule(rootModule);
 
   const redis = createRedisRuntime();
   disposers.push({ name: 'redis', dispose: () => redis.dispose() });
@@ -64,6 +65,7 @@ export function createAppRuntime(
 
   const notifications = createNotificationService({
     events: createNotificationEvents(pubsub),
+    notificationTypes,
   });
 
   const queues = createQueueRuntime(queueBindings, {

--- a/examples/blog-with-auth/apps/backend/src/modules/notifications/index.ts
+++ b/examples/blog-with-auth/apps/backend/src/modules/notifications/index.ts
@@ -1,5 +1,7 @@
 import { defineAppModule } from '@src/utils/app-modules.js';
 
+import { GENERIC_NOTIFICATION_TYPE } from './services/generic-type.js';
+
 /* TPL_IMPORTS:START */
 import './schema/notification-content.field.js';
 import './schema/notification-content.object-types.js';
@@ -7,10 +9,11 @@ import './schema/notification.mutations.js';
 import './schema/notification.object-type.js';
 import './schema/notification.queries.js';
 import './schema/notification.subscriptions.js';
-import './services/generic-type.js';
 /* TPL_IMPORTS:END */
 
 export const /* TPL_MODULE_NAME:START */ notificationsModule /* TPL_MODULE_NAME:END */ =
     defineAppModule(
-      /* TPL_MODULE_CONTENTS:START */ {} /* TPL_MODULE_CONTENTS:END */,
+      /* TPL_MODULE_CONTENTS:START */ {
+        notificationTypes: [GENERIC_NOTIFICATION_TYPE],
+      } /* TPL_MODULE_CONTENTS:END */,
     );

--- a/examples/blog-with-auth/apps/backend/src/modules/notifications/schema/notification-content.field.ts
+++ b/examples/blog-with-auth/apps/backend/src/modules/notifications/schema/notification-content.field.ts
@@ -1,17 +1,14 @@
 import { builder } from '@src/plugins/graphql/builder.js';
 
-import {
-  RENDER_SOURCE_SELECT,
-  renderContent,
-} from '../services/notification.service.js';
+import { RENDER_SOURCE_SELECT } from '../services/notification.service.js';
 import { notificationContentType } from './notification-content.object-types.js';
 import { notificationObjectType } from './notification.object-type.js';
 
 /**
- * The render-at-read site: `renderContent` re-renders from the stored source
- * (`params`) using the renderer that CREATED the row — pinned by
- * `(type, templateVersion)` — falling back to the frozen snapshot on a retired
- * renderer or param drift.
+ * The render-at-read site: `services.notifications.renderContent` re-renders
+ * from the stored source (`params`) using the renderer that CREATED the row —
+ * pinned by `(type, templateVersion)` — falling back to the frozen snapshot on
+ * a retired renderer or param drift.
  *
  * `locale` is an explicit ARG, not request context: Apollo keys its cache by
  * field args, so a language switch produces a separate cache entry instead of
@@ -27,8 +24,8 @@ builder.prismaObjectFields(
       type: notificationContentType,
       args: { locale: t.arg.string({ required: true, defaultValue: 'en' }) },
       select: RENDER_SOURCE_SELECT,
-      resolve: (notification, { locale }) =>
-        renderContent(notification, { locale }),
+      resolve: (notification, { locale }, ctx) =>
+        ctx.services.notifications.renderContent(notification, { locale }),
     }),
   }),
 );

--- a/examples/blog-with-auth/apps/backend/src/modules/notifications/services/notification-registry.ts
+++ b/examples/blog-with-auth/apps/backend/src/modules/notifications/services/notification-registry.ts
@@ -43,36 +43,20 @@ export interface NotificationTypeDefinition<
   paramsSchema: z.ZodType<P>;
   /** Eligible delivery channels, checked against the static channel dictionary. */
   channels: readonly NotificationChannelKey[];
-  /** Render content from a batch of events, in `ctx.locale`. */
-  render: (
+  /**
+   * Render content from a batch of events, in `ctx.locale`.
+   */
+  render(
     events: NotificationEvent<P>[],
     ctx: RenderContext,
-  ) => NotificationContent;
+  ): NotificationContent;
 }
 
-/** Registry key: a row's renderer is pinned by BOTH its type and its version. */
-function registryKey(key: string, version: number): string {
-  return `${key}@${version}`;
-}
-
-const registry = new Map<string, NotificationTypeDefinition>();
-
-/** Register a notification type version (call at module load). */
+/**
+ * Declares a notification type.
+ */
 export function defineNotificationType<P extends NotificationParams>(
   definition: NotificationTypeDefinition<P>,
 ): NotificationTypeDefinition<P> {
-  const id = registryKey(definition.key, definition.version);
-  if (registry.has(id)) {
-    throw new Error(`Notification type "${id}" is already defined`);
-  }
-  registry.set(id, definition as unknown as NotificationTypeDefinition);
   return definition;
-}
-
-/** Look up the renderer that a row was created with. */
-export function getNotificationType(
-  key: string,
-  version: number,
-): NotificationTypeDefinition | undefined {
-  return registry.get(registryKey(key, version));
 }

--- a/examples/blog-with-auth/apps/backend/src/modules/notifications/services/notification.service.ts
+++ b/examples/blog-with-auth/apps/backend/src/modules/notifications/services/notification.service.ts
@@ -26,7 +26,6 @@ import {
   segmentsToText,
   toSegments,
 } from './notification-content.js';
-import { getNotificationType } from './notification-registry.js';
 
 /** Default render locale until i18n lands. */
 const DEFAULT_LOCALE = 'en';
@@ -64,62 +63,9 @@ function frozenContent(row: RenderSource): RenderedContent {
   };
 }
 
-/**
- * Render a row's content at read time, ATOMICALLY: segments, fallbackText and
- * actionUrl all come from a single invocation of the renderer that CREATED the
- * row — resolved by `(type, templateVersion)`, never "whatever is deployed now".
- * A copy/param refactor bumps the version, so history can't be silently rewritten.
- *
- * Falls back to the frozen snapshot (and logs) when the pinned renderer is gone
- * or the stored params no longer satisfy it.
- */
-export function renderContent(
-  row: RenderSource,
-  ctx?: RenderContext,
-): RenderedContent {
-  const type = getNotificationType(row.type, row.templateVersion);
-  if (!type) {
-    logError(
-      new Error(
-        `No renderer for notification "${row.type}@${row.templateVersion}"`,
-      ),
-      { source: 'notification-render', notificationId: row.id },
-    );
-    return frozenContent(row);
-  }
-
-  const params = type.paramsSchema.safeParse(row.params ?? {});
-  if (!params.success) {
-    logError(params.error, {
-      source: 'notification-render',
-      reason: 'params-drift',
-      notificationId: row.id,
-      type: `${row.type}@${row.templateVersion}`,
-    });
-    return frozenContent(row);
-  }
-
-  const event: NotificationEvent = {
-    recipientId: '', // not needed to render the body
-    params: params.data,
-    actorId: row.actorId ?? undefined,
-    entityType: row.entityType ?? undefined,
-    entityId: row.entityId ?? undefined,
-  };
-
-  try {
-    return toRenderedContent(
-      type.render([event], ctx ?? { locale: DEFAULT_LOCALE }),
-    );
-  } catch (error) {
-    logError(error, {
-      source: 'notification-render',
-      reason: 'render-threw',
-      notificationId: row.id,
-      type: `${row.type}@${row.templateVersion}`,
-    });
-    return frozenContent(row);
-  }
+/** Registry key: a row's renderer is pinned by BOTH its type and its version. */
+function registryKey(key: string, version: number): string {
+  return `${key}@${version}`;
 }
 
 /** Project a renderer's output into the served content (one render, all fields). */
@@ -202,6 +148,16 @@ export interface NotificationService {
     options?: NotifyTextOptions,
   ): Promise<Notification>;
   /**
+   * Render a row's content at read time, ATOMICALLY: segments, fallbackText and
+   * actionUrl all come from a single invocation of the renderer that CREATED
+   * the row — resolved by `(type, templateVersion)` against the per-runtime
+   * registry, never "whatever is deployed now". A copy/param refactor bumps the
+   * version, so history can't be silently rewritten. Falls back to the frozen
+   * snapshot (and logs) when the pinned renderer is gone or params no longer
+   * satisfy it.
+   */
+  renderContent(row: RenderSource, ctx?: RenderContext): RenderedContent;
+  /**
    * Count of UNSEEN notifications — the bell badge. Seen (opening the panel)
    * clears the badge; read (clicking one) clears its highlight. `readAt`
    * always implies `seenAt` (see the read mutations), so this never counts a
@@ -244,9 +200,73 @@ async function getUnseenCount(userId: string): Promise<number> {
  */
 export function createNotificationService(deps: {
   events: NotificationEvents;
+  notificationTypes: NotificationTypeDefinition[];
 }): NotificationService {
-  const { events } = deps;
+  const { events, notificationTypes } = deps;
   const channels = createChannels({ events });
+
+  // Per-runtime registry: collected from `AppModule.notificationTypes` at
+  // construction. Duplicate `(key, version)` pairs fail HERE — deterministically
+  // at runtime construction — instead of at whatever import happened to load a
+  // colliding definition first.
+  const registry = new Map<string, NotificationTypeDefinition>();
+  for (const type of notificationTypes) {
+    const id = registryKey(type.key, type.version);
+    if (registry.has(id)) {
+      throw new Error(`Notification type "${id}" is already defined`);
+    }
+    registry.set(id, type);
+  }
+
+  /** Render a row's content at read time; see {@link NotificationService.renderContent}. */
+  function renderContent(
+    row: RenderSource,
+    ctx?: RenderContext,
+  ): RenderedContent {
+    const type = registry.get(registryKey(row.type, row.templateVersion));
+    if (!type) {
+      logError(
+        new Error(
+          `No renderer for notification "${row.type}@${row.templateVersion}"`,
+        ),
+        { source: 'notification-render', notificationId: row.id },
+      );
+      return frozenContent(row);
+    }
+
+    const params = type.paramsSchema.safeParse(row.params ?? {});
+    if (!params.success) {
+      logError(params.error, {
+        source: 'notification-render',
+        reason: 'params-drift',
+        notificationId: row.id,
+        type: `${row.type}@${row.templateVersion}`,
+      });
+      return frozenContent(row);
+    }
+
+    const event: NotificationEvent = {
+      recipientId: '', // not needed to render the body
+      params: params.data,
+      actorId: row.actorId ?? undefined,
+      entityType: row.entityType ?? undefined,
+      entityId: row.entityId ?? undefined,
+    };
+
+    try {
+      return toRenderedContent(
+        type.render([event], ctx ?? { locale: DEFAULT_LOCALE }),
+      );
+    } catch (error) {
+      logError(error, {
+        source: 'notification-render',
+        reason: 'render-threw',
+        notificationId: row.id,
+        type: `${row.type}@${row.templateVersion}`,
+      });
+      return frozenContent(row);
+    }
+  }
 
   /** Deliver to each of the type's channels; a channel that throws is logged, not rethrown. */
   async function dispatchToChannels(
@@ -417,6 +437,7 @@ export function createNotificationService(deps: {
   return {
     notify,
     notifyText,
+    renderContent,
     getUnseenCount,
     markAsRead,
     markAllAsSeen,

--- a/examples/blog-with-auth/apps/backend/src/modules/notifications/services/notification.service.unit.test.ts
+++ b/examples/blog-with-auth/apps/backend/src/modules/notifications/services/notification.service.unit.test.ts
@@ -4,14 +4,41 @@ import { z } from 'zod';
 import type { Prisma } from '@src/generated/prisma/client.js';
 
 import type { NotificationSegment } from './notification-content.js';
+import type { NotificationEvents } from './notification-events.js';
+import type { NotificationTypeDefinition } from './notification-registry.js';
 import type { RenderSource } from './notification.service.js';
 
 import { defineNotificationType } from './notification-registry.js';
-import { renderContent } from './notification.service.js';
+import { createNotificationService } from './notification.service.js';
 
 vi.mock('@src/services/error-logger.js', () => ({ logError: vi.fn() }));
 
 const FROZEN: NotificationSegment[] = [{ type: 'text', value: 'FROZEN v1' }];
+
+/** `renderContent` never touches pubsub, so a stub `NotificationEvents` suffices. */
+const fakeEvents: NotificationEvents = {
+  publishUnseenCount: vi.fn(),
+  subscribeToUnseenCount: vi.fn(),
+};
+
+/** Build a service whose registry holds exactly the supplied types. */
+function serviceWith(
+  notificationTypes: NotificationTypeDefinition[],
+): ReturnType<typeof createNotificationService> {
+  return createNotificationService({ events: fakeEvents, notificationTypes });
+}
+
+/**
+ * The service's `renderContent`, wrapped so tests can call it directly.
+ * Wrapped (not destructured) because `renderContent` is an interface method;
+ * pulling it off the object bare would trip `@typescript-eslint/unbound-method`.
+ */
+function renderWith(
+  notificationTypes: NotificationTypeDefinition[],
+): ReturnType<typeof createNotificationService>['renderContent'] {
+  const service = serviceWith(notificationTypes);
+  return (row, ctx) => service.renderContent(row, ctx);
+}
 
 /** A persisted row whose frozen columns act as the recovery content. */
 function makeRow(
@@ -35,13 +62,15 @@ function makeRow(
 
 describe('renderContent (versioned render-at-read)', () => {
   it('renders LIVE from stored params, not the frozen snapshot', () => {
-    defineNotificationType({
-      key: 'test.live',
-      version: 1,
-      paramsSchema: z.object({ name: z.string() }),
-      channels: ['inApp'],
-      render: ([event]) => ({ body: `${event.params.name} commented` }),
-    });
+    const renderContent = renderWith([
+      defineNotificationType({
+        key: 'test.live',
+        version: 1,
+        paramsSchema: z.object({ name: z.string() }),
+        channels: ['inApp'],
+        render: ([event]) => ({ body: `${event.params.name} commented` }),
+      }),
+    ]);
 
     const content = renderContent(makeRow('test.live', 1, { name: 'Alice' }));
 
@@ -54,20 +83,22 @@ describe('renderContent (versioned render-at-read)', () => {
   it('PINS a row to the renderer version that created it', () => {
     // v1 and v2 of the same type are both registered. A row stamped v1 must keep
     // rendering with v1 even though v2 is the newest — history is not rewritten.
-    defineNotificationType({
-      key: 'test.versioned',
-      version: 1,
-      paramsSchema: z.object({ name: z.string() }),
-      channels: ['inApp'],
-      render: ([event]) => ({ body: `v1: ${event.params.name}` }),
-    });
-    defineNotificationType({
-      key: 'test.versioned',
-      version: 2,
-      paramsSchema: z.object({ name: z.string() }),
-      channels: ['inApp'],
-      render: ([event]) => ({ body: `v2: ${event.params.name}` }),
-    });
+    const renderContent = renderWith([
+      defineNotificationType({
+        key: 'test.versioned',
+        version: 1,
+        paramsSchema: z.object({ name: z.string() }),
+        channels: ['inApp'],
+        render: ([event]) => ({ body: `v1: ${event.params.name}` }),
+      }),
+      defineNotificationType({
+        key: 'test.versioned',
+        version: 2,
+        paramsSchema: z.object({ name: z.string() }),
+        channels: ['inApp'],
+        render: ([event]) => ({ body: `v2: ${event.params.name}` }),
+      }),
+    ]);
 
     const oldRow = renderContent(makeRow('test.versioned', 1, { name: 'Al' }));
     const newRow = renderContent(makeRow('test.versioned', 2, { name: 'Al' }));
@@ -77,16 +108,18 @@ describe('renderContent (versioned render-at-read)', () => {
   });
 
   it('renders content ATOMICALLY (segments, text and actionUrl from one render)', () => {
-    defineNotificationType({
-      key: 'test.atomic',
-      version: 1,
-      paramsSchema: z.object({ postId: z.string() }),
-      channels: ['inApp'],
-      render: ([event]) => ({
-        body: 'commented on your post',
-        actionUrl: `/posts/${event.params.postId}`,
+    const renderContent = renderWith([
+      defineNotificationType({
+        key: 'test.atomic',
+        version: 1,
+        paramsSchema: z.object({ postId: z.string() }),
+        channels: ['inApp'],
+        render: ([event]) => ({
+          body: 'commented on your post',
+          actionUrl: `/posts/${event.params.postId}`,
+        }),
       }),
-    });
+    ]);
 
     const content = renderContent(makeRow('test.atomic', 1, { postId: 'p9' }));
 
@@ -96,19 +129,22 @@ describe('renderContent (versioned render-at-read)', () => {
   });
 
   it('falls back to the frozen snapshot when the renderer is retired', () => {
+    const renderContent = renderWith([]);
     const content = renderContent(makeRow('test.gone', 1, { name: 'Bob' }));
     expect(content.segments).toEqual(FROZEN);
     expect(content.actionUrl).toBe('/frozen');
   });
 
   it('falls back to the frozen snapshot when stored params drift', () => {
-    defineNotificationType({
-      key: 'test.drift',
-      version: 1,
-      paramsSchema: z.object({ title: z.string() }),
-      channels: ['inApp'],
-      render: ([event]) => ({ body: event.params.title }),
-    });
+    const renderContent = renderWith([
+      defineNotificationType({
+        key: 'test.drift',
+        version: 1,
+        paramsSchema: z.object({ title: z.string() }),
+        channels: ['inApp'],
+        render: ([event]) => ({ body: event.params.title }),
+      }),
+    ]);
 
     // Row predates the `title` param → schema validation fails → frozen.
     const drifted = renderContent(makeRow('test.drift', 1, { old: 1 }));
@@ -120,16 +156,18 @@ describe('renderContent (versioned render-at-read)', () => {
   });
 
   it('rejects unsafe actionUrl schemes', () => {
-    defineNotificationType({
-      key: 'test.unsafe-url',
-      version: 1,
-      paramsSchema: z.object({}),
-      channels: ['inApp'],
-      render: () => ({
-        body: 'hi',
-        actionUrl: 'javascript:alert(1)',
+    const renderContent = renderWith([
+      defineNotificationType({
+        key: 'test.unsafe-url',
+        version: 1,
+        paramsSchema: z.object({}),
+        channels: ['inApp'],
+        render: () => ({
+          body: 'hi',
+          actionUrl: 'javascript:alert(1)',
+        }),
       }),
-    });
+    ]);
 
     expect(
       renderContent(makeRow('test.unsafe-url', 1, {})).actionUrl,
@@ -139,18 +177,66 @@ describe('renderContent (versioned render-at-read)', () => {
   it('rejects an unsafe href in a LIVE renderer segment (falls back to frozen)', () => {
     // A renderer emitting a `javascript:` link must NOT reach the client: the
     // segment schema rejects it, render throws, and we fall back to frozen.
-    defineNotificationType({
-      key: 'test.unsafe-segment',
-      version: 1,
-      paramsSchema: z.object({}),
-      channels: ['inApp'],
-      render: () => ({
-        body: [{ type: 'link', value: 'click', href: 'javascript:alert(1)' }],
+    const renderContent = renderWith([
+      defineNotificationType({
+        key: 'test.unsafe-segment',
+        version: 1,
+        paramsSchema: z.object({}),
+        channels: ['inApp'],
+        render: () => ({
+          body: [{ type: 'link', value: 'click', href: 'javascript:alert(1)' }],
+        }),
       }),
-    });
+    ]);
 
     expect(
       renderContent(makeRow('test.unsafe-segment', 1, {})).segments,
     ).toEqual(FROZEN);
+  });
+});
+
+describe('createNotificationService (registry construction invariant)', () => {
+  it('throws at construction when a (key, version) pair is registered twice', () => {
+    const first = defineNotificationType({
+      key: 'test.dup',
+      version: 1,
+      paramsSchema: z.object({}),
+      channels: ['inApp'],
+      render: () => ({ body: 'first' }),
+    });
+    const second = defineNotificationType({
+      key: 'test.dup',
+      version: 1,
+      paramsSchema: z.object({}),
+      channels: ['inApp'],
+      render: () => ({ body: 'second' }),
+    });
+
+    // The collision surfaces deterministically at runtime construction — citing
+    // the duplicated identifier — not at whatever import happened to load first.
+    expect(() => serviceWith([first, second])).toThrow(
+      'Notification type "test.dup@1" is already defined',
+    );
+  });
+
+  it('allows the same key across different versions', () => {
+    expect(() =>
+      serviceWith([
+        defineNotificationType({
+          key: 'test.multiversion',
+          version: 1,
+          paramsSchema: z.object({}),
+          channels: ['inApp'],
+          render: () => ({ body: 'v1' }),
+        }),
+        defineNotificationType({
+          key: 'test.multiversion',
+          version: 2,
+          paramsSchema: z.object({}),
+          channels: ['inApp'],
+          render: () => ({ body: 'v2' }),
+        }),
+      ]),
+    ).not.toThrow();
   });
 });

--- a/examples/blog-with-auth/apps/backend/src/utils/app-modules.ts
+++ b/examples/blog-with-auth/apps/backend/src/utils/app-modules.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync, FastifyPluginCallback } from 'fastify';
 
+import type { NotificationTypeDefinition } from '../modules/notifications/services/notification-registry.js';
 import type { QueueHandlerBinding } from '../types/queue.types.js';
 import type { AppServices } from './runtime-services.js';
 
@@ -37,6 +38,7 @@ export type AppPlugin =
 export interface AppModule {
   children?: AppModule[];
   /* TPL_MODULE_FIELDS:START */
+  notificationTypes?: NotificationTypeDefinition[];
   plugins?: AppPlugin[];
   queues?: QueueHandlerBinding[];
   /* TPL_MODULE_FIELDS:END */
@@ -68,12 +70,14 @@ export function flattenAppModule(
   const flattenedChildren = children.map(flattenAppModule);
 
   const result = /* TPL_MODULE_INITIALIZER:START */ {
+    notificationTypes: [...(rootModule.notificationTypes ?? [])],
     plugins: [...(rootModule.plugins ?? [])],
     queues: [...(rootModule.queues ?? [])],
   }; /* TPL_MODULE_INITIALIZER:END */
 
   for (const child of flattenedChildren) {
     /* TPL_MODULE_MERGER:START */
+    result.notificationTypes.push(...(child.notificationTypes ?? []));
     result.plugins.push(...(child.plugins ?? []));
     result.queues.push(...(child.queues ?? []));
     /* TPL_MODULE_MERGER:END */

--- a/examples/blog-with-auth/apps/backend/src/utils/app-runtime.ts
+++ b/examples/blog-with-auth/apps/backend/src/utils/app-runtime.ts
@@ -53,7 +53,8 @@ export function createAppRuntime(
   let disposePromise: Promise<void> | undefined;
 
   /* TPL_SERVICE_CONSTRUCTION:START */
-  const { queues: queueBindings = [] } = flattenAppModule(rootModule);
+  const { notificationTypes = [], queues: queueBindings = [] } =
+    flattenAppModule(rootModule);
 
   const redis = createRedisRuntime();
   disposers.push({ name: 'redis', dispose: () => redis.dispose() });
@@ -64,6 +65,7 @@ export function createAppRuntime(
 
   const notifications = createNotificationService({
     events: createNotificationEvents(pubsub),
+    notificationTypes,
   });
 
   const queues = createQueueRuntime(queueBindings, {

--- a/plugins/plugin-notifications/src/notifications/core/generators/notification-module/notification-module.generator.ts
+++ b/plugins/plugin-notifications/src/notifications/core/generators/notification-module/notification-module.generator.ts
@@ -1,5 +1,7 @@
 import { tsCodeFragment, TsCodeUtils } from '@baseplate-dev/core-generators';
 import {
+  appModuleConfigProvider,
+  appModuleFieldTypesProvider,
   appModuleProvider,
   appRuntimeConfigProvider,
   pothosSchemaProvider,
@@ -40,14 +42,44 @@ export const notificationModuleGenerator = createGenerator({
             paths.servicesNotificationService,
           ),
         );
+        appRuntimeConfig.flattenedModuleFields.set(
+          'notificationTypes',
+          'notificationTypes',
+        );
         appRuntimeConfig.construction.set('notifications', {
           dependencies: ['pubsub'],
           fragment: TsCodeUtils.template`
             const notifications = ${TsCodeUtils.importFragment('createNotificationService', paths.servicesNotificationService)}({
               events: ${TsCodeUtils.importFragment('createNotificationEvents', paths.servicesNotificationEvents)}(pubsub),
+              notificationTypes,
             });
           `,
         });
+      },
+    }),
+    // Declared without a type here and bound below, once `paths` can be
+    // resolved (the element type lives inside this module).
+    appModuleConfig: createGeneratorTask({
+      dependencies: {
+        appModuleConfig: appModuleConfigProvider,
+      },
+      run({ appModuleConfig }) {
+        appModuleConfig.moduleFields.set('notificationTypes', undefined);
+      },
+    }),
+    appModuleFieldTypes: createGeneratorTask({
+      dependencies: {
+        appModuleFieldTypes: appModuleFieldTypesProvider,
+        paths: NOTIFICATIONS_CORE_NOTIFICATION_MODULE_GENERATED.paths.provider,
+      },
+      run({ appModuleFieldTypes, paths }) {
+        appModuleFieldTypes.setFieldType(
+          'notificationTypes',
+          TsCodeUtils.typeImportFragment(
+            'NotificationTypeDefinition',
+            paths.servicesNotificationRegistry,
+          ),
+        );
       },
     }),
     main: createGeneratorTask({
@@ -79,9 +111,17 @@ export const notificationModuleGenerator = createGenerator({
           pothosSchema.registerSchemaFile(renderedPath);
         }
 
-        // Import the built-in `generic` type for its side effect (it registers
-        // itself on load, backing `notifyText`).
-        appModule.moduleImports.push(paths.servicesGenericType);
+        // Contribute the built-in `generic` type (backing `notifyText`) as a
+        // module declaration; the runtime collects it into the per-runtime
+        // registry at construction — no import-time side effect.
+        appModule.moduleFields.set(
+          'notificationTypes',
+          'generic',
+          TsCodeUtils.importFragment(
+            'GENERIC_NOTIFICATION_TYPE',
+            paths.servicesGenericType,
+          ),
+        );
 
         // Contribute the real-time channel to the pubsub type map.
         yogaPluginConfig.publishArgs.set(

--- a/plugins/plugin-notifications/src/notifications/core/generators/notification-module/templates/module/schema/notification-content.field.ts
+++ b/plugins/plugin-notifications/src/notifications/core/generators/notification-module/templates/module/schema/notification-content.field.ts
@@ -1,17 +1,14 @@
 // @ts-nocheck
 
 import { notificationContentType } from '$schemaNotificationContentObjectTypes';
-import {
-  RENDER_SOURCE_SELECT,
-  renderContent,
-} from '$servicesNotificationService';
+import { RENDER_SOURCE_SELECT } from '$servicesNotificationService';
 import { builder } from '%pothosImports';
 
 /**
- * The render-at-read site: `renderContent` re-renders from the stored source
- * (`params`) using the renderer that CREATED the row — pinned by
- * `(type, templateVersion)` — falling back to the frozen snapshot on a retired
- * renderer or param drift.
+ * The render-at-read site: `services.notifications.renderContent` re-renders
+ * from the stored source (`params`) using the renderer that CREATED the row —
+ * pinned by `(type, templateVersion)` — falling back to the frozen snapshot on
+ * a retired renderer or param drift.
  *
  * `locale` is an explicit ARG, not request context: Apollo keys its cache by
  * field args, so a language switch produces a separate cache entry instead of
@@ -25,7 +22,7 @@ builder.prismaObjectFields(TPL_NOTIFICATION_OBJECT_TYPE, (t) => ({
     type: notificationContentType,
     args: { locale: t.arg.string({ required: true, defaultValue: 'en' }) },
     select: RENDER_SOURCE_SELECT,
-    resolve: (notification, { locale }) =>
-      renderContent(notification, { locale }),
+    resolve: (notification, { locale }, ctx) =>
+      ctx.services.notifications.renderContent(notification, { locale }),
   }),
 }));

--- a/plugins/plugin-notifications/src/notifications/core/generators/notification-module/templates/module/services/notification-registry.ts
+++ b/plugins/plugin-notifications/src/notifications/core/generators/notification-module/templates/module/services/notification-registry.ts
@@ -44,36 +44,20 @@ export interface NotificationTypeDefinition<
   paramsSchema: z.ZodType<P>;
   /** Eligible delivery channels, checked against the static channel dictionary. */
   channels: readonly NotificationChannelKey[];
-  /** Render content from a batch of events, in `ctx.locale`. */
-  render: (
+  /**
+   * Render content from a batch of events, in `ctx.locale`.
+   */
+  render(
     events: NotificationEvent<P>[],
     ctx: RenderContext,
-  ) => NotificationContent;
+  ): NotificationContent;
 }
 
-/** Registry key: a row's renderer is pinned by BOTH its type and its version. */
-function registryKey(key: string, version: number): string {
-  return `${key}@${version}`;
-}
-
-const registry = new Map<string, NotificationTypeDefinition>();
-
-/** Register a notification type version (call at module load). */
+/**
+ * Declares a notification type.
+ */
 export function defineNotificationType<P extends NotificationParams>(
   definition: NotificationTypeDefinition<P>,
 ): NotificationTypeDefinition<P> {
-  const id = registryKey(definition.key, definition.version);
-  if (registry.has(id)) {
-    throw new Error(`Notification type "${id}" is already defined`);
-  }
-  registry.set(id, definition as unknown as NotificationTypeDefinition);
   return definition;
-}
-
-/** Look up the renderer that a row was created with. */
-export function getNotificationType(
-  key: string,
-  version: number,
-): NotificationTypeDefinition | undefined {
-  return registry.get(registryKey(key, version));
 }

--- a/plugins/plugin-notifications/src/notifications/core/generators/notification-module/templates/module/services/notification.service.ts
+++ b/plugins/plugin-notifications/src/notifications/core/generators/notification-module/templates/module/services/notification.service.ts
@@ -24,7 +24,6 @@ import {
   segmentsToText,
   toSegments,
 } from '$servicesNotificationContent';
-import { getNotificationType } from '$servicesNotificationRegistry';
 import { logError } from '%errorHandlerServiceImports';
 import { prisma } from '%prismaImports';
 
@@ -64,62 +63,9 @@ function frozenContent(row: RenderSource): RenderedContent {
   };
 }
 
-/**
- * Render a row's content at read time, ATOMICALLY: segments, fallbackText and
- * actionUrl all come from a single invocation of the renderer that CREATED the
- * row — resolved by `(type, templateVersion)`, never "whatever is deployed now".
- * A copy/param refactor bumps the version, so history can't be silently rewritten.
- *
- * Falls back to the frozen snapshot (and logs) when the pinned renderer is gone
- * or the stored params no longer satisfy it.
- */
-export function renderContent(
-  row: RenderSource,
-  ctx?: RenderContext,
-): RenderedContent {
-  const type = getNotificationType(row.type, row.templateVersion);
-  if (!type) {
-    logError(
-      new Error(
-        `No renderer for notification "${row.type}@${row.templateVersion}"`,
-      ),
-      { source: 'notification-render', notificationId: row.id },
-    );
-    return frozenContent(row);
-  }
-
-  const params = type.paramsSchema.safeParse(row.params ?? {});
-  if (!params.success) {
-    logError(params.error, {
-      source: 'notification-render',
-      reason: 'params-drift',
-      notificationId: row.id,
-      type: `${row.type}@${row.templateVersion}`,
-    });
-    return frozenContent(row);
-  }
-
-  const event: NotificationEvent = {
-    recipientId: '', // not needed to render the body
-    params: params.data,
-    actorId: row.actorId ?? undefined,
-    entityType: row.entityType ?? undefined,
-    entityId: row.entityId ?? undefined,
-  };
-
-  try {
-    return toRenderedContent(
-      type.render([event], ctx ?? { locale: DEFAULT_LOCALE }),
-    );
-  } catch (error) {
-    logError(error, {
-      source: 'notification-render',
-      reason: 'render-threw',
-      notificationId: row.id,
-      type: `${row.type}@${row.templateVersion}`,
-    });
-    return frozenContent(row);
-  }
+/** Registry key: a row's renderer is pinned by BOTH its type and its version. */
+function registryKey(key: string, version: number): string {
+  return `${key}@${version}`;
 }
 
 /** Project a renderer's output into the served content (one render, all fields). */
@@ -202,6 +148,16 @@ export interface NotificationService {
     options?: NotifyTextOptions,
   ): Promise<Notification>;
   /**
+   * Render a row's content at read time, ATOMICALLY: segments, fallbackText and
+   * actionUrl all come from a single invocation of the renderer that CREATED
+   * the row — resolved by `(type, templateVersion)` against the per-runtime
+   * registry, never "whatever is deployed now". A copy/param refactor bumps the
+   * version, so history can't be silently rewritten. Falls back to the frozen
+   * snapshot (and logs) when the pinned renderer is gone or params no longer
+   * satisfy it.
+   */
+  renderContent(row: RenderSource, ctx?: RenderContext): RenderedContent;
+  /**
    * Count of UNSEEN notifications — the bell badge. Seen (opening the panel)
    * clears the badge; read (clicking one) clears its highlight. `readAt`
    * always implies `seenAt` (see the read mutations), so this never counts a
@@ -244,9 +200,73 @@ async function getUnseenCount(userId: string): Promise<number> {
  */
 export function createNotificationService(deps: {
   events: NotificationEvents;
+  notificationTypes: NotificationTypeDefinition[];
 }): NotificationService {
-  const { events } = deps;
+  const { events, notificationTypes } = deps;
   const channels = createChannels({ events });
+
+  // Per-runtime registry: collected from `AppModule.notificationTypes` at
+  // construction. Duplicate `(key, version)` pairs fail HERE — deterministically
+  // at runtime construction — instead of at whatever import happened to load a
+  // colliding definition first.
+  const registry = new Map<string, NotificationTypeDefinition>();
+  for (const type of notificationTypes) {
+    const id = registryKey(type.key, type.version);
+    if (registry.has(id)) {
+      throw new Error(`Notification type "${id}" is already defined`);
+    }
+    registry.set(id, type);
+  }
+
+  /** Render a row's content at read time; see {@link NotificationService.renderContent}. */
+  function renderContent(
+    row: RenderSource,
+    ctx?: RenderContext,
+  ): RenderedContent {
+    const type = registry.get(registryKey(row.type, row.templateVersion));
+    if (!type) {
+      logError(
+        new Error(
+          `No renderer for notification "${row.type}@${row.templateVersion}"`,
+        ),
+        { source: 'notification-render', notificationId: row.id },
+      );
+      return frozenContent(row);
+    }
+
+    const params = type.paramsSchema.safeParse(row.params ?? {});
+    if (!params.success) {
+      logError(params.error, {
+        source: 'notification-render',
+        reason: 'params-drift',
+        notificationId: row.id,
+        type: `${row.type}@${row.templateVersion}`,
+      });
+      return frozenContent(row);
+    }
+
+    const event: NotificationEvent = {
+      recipientId: '', // not needed to render the body
+      params: params.data,
+      actorId: row.actorId ?? undefined,
+      entityType: row.entityType ?? undefined,
+      entityId: row.entityId ?? undefined,
+    };
+
+    try {
+      return toRenderedContent(
+        type.render([event], ctx ?? { locale: DEFAULT_LOCALE }),
+      );
+    } catch (error) {
+      logError(error, {
+        source: 'notification-render',
+        reason: 'render-threw',
+        notificationId: row.id,
+        type: `${row.type}@${row.templateVersion}`,
+      });
+      return frozenContent(row);
+    }
+  }
 
   /** Deliver to each of the type's channels; a channel that throws is logged, not rethrown. */
   async function dispatchToChannels(
@@ -417,6 +437,7 @@ export function createNotificationService(deps: {
   return {
     notify,
     notifyText,
+    renderContent,
     getUnseenCount,
     markAsRead,
     markAllAsSeen,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification types are now configured during application startup, enabling isolated runtime registries.
  * Notification content continues to render dynamically, with improved fallback to saved content when renderers are unavailable, invalid, or fail.
  * Duplicate notification type versions are detected during startup.
* **Bug Fixes**
  * Improved notification rendering reliability and security validation for links and action URLs.
  * Preserved previously saved notification content when current rendering data is incompatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->