### PR TITLE
fix: Cap vitest workers to 8 when running in integration test mode

### DIFF
--- a/.changeset/cap-prisma-vitest-max-workers.md
+++ b/.changeset/cap-prisma-vitest-max-workers.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/fastify-generators': patch
+---
+
+Generated backends now cap Vitest to 8 parallel workers for the default `test` run, since each worker clones its own database from the template; `pnpm test:unit` (`TEST_MODE=unit`) remains uncapped since it has no database involvement.

--- a/.changeset/cap-vitest-max-workers-for-db-backed-tests.md
+++ b/.changeset/cap-vitest-max-workers-for-db-backed-tests.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/core-generators': patch
+---
+
+The generated `vitest.config.ts` now supports an optional `maxWorkers` value so DB-backed test suites can cap parallel Vitest workers, avoiding Postgres connection or clone-lock exhaustion on high-core CI runners while unit-only runs stay uncapped.

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/vitest.config.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(
       dir: 'src',
       env: loadEnv('development', process.cwd(), ''),
       globalSetup: ['src/tests/scripts/global-setup-prisma.ts'],
+      maxWorkers: process.env.TEST_MODE === 'unit' ? undefined : 8,
       passWithNoTests: true,
       setupFiles: [
         'src/tests/scripts/setup-db.ts',

--- a/examples/blog-with-auth/apps/backend/vitest.config.ts
+++ b/examples/blog-with-auth/apps/backend/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(
       dir: 'src',
       env: loadEnv('development', process.cwd(), ''),
       globalSetup: ['src/tests/scripts/global-setup-prisma.ts'],
+      maxWorkers: process.env.TEST_MODE === 'unit' ? undefined : 8,
       passWithNoTests: true,
       setupFiles: [
         'src/tests/scripts/setup-db.ts',

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/vitest.config.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(
       dir: 'src',
       env: loadEnv('development', process.cwd(), ''),
       globalSetup: ['src/tests/scripts/global-setup-prisma.ts'],
+      maxWorkers: process.env.TEST_MODE === 'unit' ? undefined : 8,
       passWithNoTests: true,
       setupFiles: [
         'src/tests/scripts/setup-db.ts',

--- a/examples/todo-with-better-auth/apps/backend/vitest.config.ts
+++ b/examples/todo-with-better-auth/apps/backend/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(
       dir: 'src',
       env: loadEnv('development', process.cwd(), ''),
       globalSetup: ['src/tests/scripts/global-setup-prisma.ts'],
+      maxWorkers: process.env.TEST_MODE === 'unit' ? undefined : 8,
       passWithNoTests: true,
       setupFiles: [
         'src/tests/scripts/setup-db.ts',

--- a/packages/core-generators/src/generators/node/vitest/vitest.generator.ts
+++ b/packages/core-generators/src/generators/node/vitest/vitest.generator.ts
@@ -28,6 +28,7 @@ const [setupTask, vitestConfigProvider, vitestConfigValuesProvider] =
     (t) => ({
       globalSetupFiles: t.array<string>(),
       setupFiles: t.array<string>(),
+      maxWorkers: t.number(),
     }),
     {
       prefix: 'vitest',
@@ -61,7 +62,7 @@ export const vitestGenerator = createGenerator({
       },
       run({
         eslintConfig,
-        vitestConfigValues: { globalSetupFiles, setupFiles },
+        vitestConfigValues: { globalSetupFiles, setupFiles, maxWorkers },
         renderers,
       }) {
         eslintConfig.enableVitest.set(true);
@@ -84,6 +85,13 @@ export const vitestGenerator = createGenerator({
                 "loadEnv('development', process.cwd(), '')",
                 tsImportBuilder(['loadEnv']).from('vite'),
               ),
+              // TEST_MODE=unit runs have no DB involvement and keep full parallelism.
+              maxWorkers:
+                maxWorkers === undefined
+                  ? undefined
+                  : tsCodeFragment(
+                      `process.env.TEST_MODE === 'unit' ? undefined : ${maxWorkers}`,
+                    ),
             });
 
             await builder.apply(

--- a/packages/fastify-generators/src/generators/vitest/prisma-vitest/prisma-vitest.generator.ts
+++ b/packages/fastify-generators/src/generators/vitest/prisma-vitest/prisma-vitest.generator.ts
@@ -27,6 +27,13 @@ const POSTGRES_MAX_IDENTIFIER_BYTES = 63;
 const TEMPLATE_SUFFIX_BYTES = '_template'.length;
 
 /**
+ * Cap on parallel Vitest workers for DB-backed runs. Each worker clones its own
+ * database from the template, so uncapped worker counts on high-core CI runners
+ * can exhaust `max_connections` or hit clone-lock contention on the template.
+ */
+const DB_BACKED_TEST_MAX_WORKERS = 8;
+
+/**
  * Validates the base test database name derived from the package name.
  *
  * The name is interpolated into `CREATE`/`DROP DATABASE` in the generated test
@@ -122,6 +129,8 @@ export const prismaVitestGenerator = createGenerator({
             vitestConfig.setupFiles.push(
               normalizePathToOutputPath(paths.setupDb),
             );
+
+            vitestConfig.maxWorkers.set(DB_BACKED_TEST_MAX_WORKERS);
           },
         };
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Database-backed Vitest test runs now limit parallel workers to 8, helping prevent PostgreSQL connection and resource exhaustion in high-core environments.
  - Unit-only test runs remain uncapped and can continue using Vitest’s default parallelism.

- **Documentation**
  - Added release notes describing the new worker-limit behavior for generated projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->