### PR TITLE
feat: Support one-to-many relations in model authorizer expressions

### DIFF
--- a/.changeset/brown-jars-behave.md
+++ b/.changeset/brown-jars-behave.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/plugin-ai': patch
+---
+
+Generate an `.agents/authorization.md` guide in new projects documenting the authorization model and the expression DSL used by model roles, and link to it from `AGENTS.md`, `CLAUDE.md`, and `.agents/baseplate.md`.

--- a/.changeset/olive-donkeys-shout.md
+++ b/.changeset/olive-donkeys-shout.md
@@ -1,0 +1,7 @@
+---
+'@baseplate-dev/project-builder-server': patch
+'@baseplate-dev/project-builder-web': patch
+'@baseplate-dev/project-builder-lib': patch
+---
+
+Support one-to-many relations in model authorizer expressions, so `hasRole(model.members, 'owner')` now delegates to a role on a has-many relation ("some related record grants the role") instead of failing to build, and the expression editor suggests has-many relations for `hasRole`/`hasSomeRole` alongside belongs-to ones.

--- a/.changeset/tall-cooks-shave.md
+++ b/.changeset/tall-cooks-shave.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/fastify-generators': patch
+---
+
+Add `r.viaMany` to model authorizers for delegating a role across a to-many relation — a row holds the role if some related row grants it, emitted as `{ relation: { some: … } }` and checked with a single query. The relation is constrained at the type level to relations that actually point at the target policy's model, so a mismatched pairing is a compile error rather than a filter against the wrong model.

--- a/.changeset/violet-pugs-marry.md
+++ b/.changeset/violet-pugs-marry.md
@@ -1,0 +1,6 @@
+---
+'@baseplate-dev/project-builder-server': patch
+'@baseplate-dev/project-builder-lib': patch
+---
+
+Annotate expression fields in the entity schema returned by `get-entity-schema`, so authorization expressions are identified as a DSL with a short syntax summary and a pointer to the full grammar instead of appearing as a plain string.

--- a/.claude/skills/add-component/SKILL.md
+++ b/.claude/skills/add-component/SKILL.md
@@ -228,5 +228,4 @@ Add <ComponentName> component
 ## Important Notes
 
 - Never manually edit files in `generated/` directories — they are auto-generated.
-- Only modify: template source files in `templates/`, `extractor.json`, and the main `*.generator.ts`.
 - If you hit more than two cycles of type/lint errors after extraction, stop and ask the user for help.

--- a/examples/blog-with-auth/.agents/.templates-info.json
+++ b/examples/blog-with-auth/.agents/.templates-info.json
@@ -1,4 +1,9 @@
 {
+  "authorization.md": {
+    "generator": "@baseplate-dev/plugin-ai#dev-agents/core/dev-agents-config",
+    "instanceData": { "variables": {} },
+    "template": "authorization-md"
+  },
   "baseplate.md": {
     "generator": "@baseplate-dev/plugin-ai#dev-agents/core/dev-agents-config",
     "instanceData": {

--- a/examples/blog-with-auth/.agents/authorization.md
+++ b/examples/blog-with-auth/.agents/authorization.md
@@ -1,0 +1,74 @@
+# Authorization
+
+Authorization is declared in the project definition and compiled into a policy
+per model. Nothing is hand-written in the generated policy files.
+
+Each model has an **authorizer** with named **roles**. A role is a predicate over
+a row ("is this principal the owner of this blog?"). Actions (`read`, `create`,
+`update`, `delete`) then grant access to a set of roles:
+
+- `roles` — instance roles, evaluated per row
+- `globalRoles` — principal-level roles (e.g. `admin`, `public`), row-independent
+
+A role compiles to both a boolean check (against a loaded row) and a Prisma
+`where` filter (to fan out over a list), derived from the same declaration — so
+"can I see this one?" and "which ones can I see?" can never disagree.
+
+## Authorization Expressions
+
+Each role's `expression` is a **JS-like boolean DSL** — it looks like TypeScript
+but only the following constructs are valid.
+
+| Construct                                    | Meaning                                                     |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| `model.<field> === userId`                   | Compare a field on the row to the principal (`!==` also OK) |
+| `model.<field> === 'literal'`                | Compare a field to a string/number/boolean literal          |
+| `isAuthenticated`                            | Any signed-in principal                                     |
+| `hasRole('admin')`                           | Principal holds a global role                               |
+| `hasSomeRole(['admin', 'editor'])`           | Principal holds any of several global roles                 |
+| `hasRole(model.<relation>, 'role')`          | **Delegate** to a role on a related model                   |
+| `hasSomeRole(model.<relation>, ['a', 'b'])`  | Delegate, matching any of several roles                     |
+| `exists(model.<relation>, { field: value })` | Some related record matches the conditions                  |
+| `all(model.<relation>, { field: value })`    | Every related record matches the conditions                 |
+| `&&`, `\|\|`                                 | Combine any of the above                                    |
+
+Available context: `model.<field>` (the row), `userId` and `isAuthenticated`
+(the principal). `userId` is the only auth property.
+
+**Delegation (`hasRole` with a relation)** is the main tool for reuse — instead
+of restating a parent's rule on the child, point at it:
+
+```js
+// BlogPost.owner — delegate to the Blog's own `owner` role (belongs-to)
+hasRole(model.blog, 'owner');
+
+// Blog.member — "some related BlogUser grants `owner`" (has-many)
+hasRole(model.members, 'owner');
+```
+
+Both relation directions work. A belongs-to relation delegates to the single
+related record; a has-many relation is **existential** — at least one related
+record must grant the role. A row with no related records is never granted the
+role, even if the delegated role is otherwise unrestricted.
+
+`exists`/`all` are the direct-predicate alternative when there is no role to
+reuse — they match on _fields_ of the related records, and require a has-many
+relation:
+
+```js
+// "I'm a member of this blog", stated inline rather than delegated
+exists(model.members, { userId: userId });
+```
+
+Prefer `hasRole(model.<relation>, ...)` when the related model already defines
+the role — it stays correct when that role's definition changes.
+
+## Editing authorization
+
+Roles live under a model's `authorizer.roles`; grants live on `graphql.queries`
+(read) and `service.{create,update,delete}`. Use `stage-patch-entity` on the
+`model` entity, then `show-draft` and `commit-draft`. The expression is
+validated on save — an unknown field, relation, or role surfaces as a warning
+rather than failing silently.
+
+See [baseplate.md](baseplate.md) for the general MCP workflow.

--- a/examples/blog-with-auth/.agents/baseplate.md
+++ b/examples/blog-with-auth/.agents/baseplate.md
@@ -68,6 +68,15 @@ Each model has:
 
 Common field types: `string`, `int`, `float`, `boolean`, `datetime`, `json`, `enum`
 
+## Authorization
+
+Models declare authorization as named roles whose `expression` is a JS-like
+boolean DSL (`model.userId === userId`, `hasRole(model.blog, 'owner')`,
+`exists(model.members, { userId: userId })`).
+
+See [authorization.md](authorization.md) for the full grammar, delegation across
+relations, and how to edit roles and grants.
+
 ## Tips
 
 - **Prefer MCP tools over editing `project-definition.json` directly** — The MCP server validates changes and maintains referential integrity

--- a/examples/blog-with-auth/AGENTS.md
+++ b/examples/blog-with-auth/AGENTS.md
@@ -57,3 +57,4 @@ This is a pnpm monorepo managed with Turborepo. Key directories:
 This project uses Baseplate for code generation. The project definition is stored in `baseplate/project-definition.json`.
 
 - See `.agents/baseplate.md` for how to use the Baseplate MCP server, modify data models, and manage plugins
+- See `.agents/authorization.md` for the authorization model and the expression DSL used by model roles

--- a/examples/blog-with-auth/CLAUDE.md
+++ b/examples/blog-with-auth/CLAUDE.md
@@ -6,4 +6,5 @@ See [AGENTS.md](AGENTS.md) for full project context, build commands, and convent
 
 - **Prefer Baseplate MCP tools** over editing `project-definition.json` directly — the MCP server validates changes and maintains referential integrity
 - See `.agents/baseplate.md` for MCP server usage, data model changes, and plugin management
+- See `.agents/authorization.md` for the authorization model and expression DSL
 - Generated code lives in `baseplate/generated/` directories — do not edit these files directly

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/blogs/authorizers/blog.policy.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/modules/blogs/authorizers/blog.policy.ts
@@ -1,6 +1,8 @@
 import { prisma } from '@src/services/prisma.js';
 import { createModelPolicy } from '@src/utils/authorizers/create-model-policy.js';
 
+import { blogUserPolicy } from './blog-user.policy.js';
+
 export const blogPolicy = createModelPolicy({
   model: 'blog',
   id: 'id',
@@ -10,9 +12,10 @@ export const blogPolicy = createModelPolicy({
     viewer: r.userWhere((session) => ({
       members: { some: { userId: session.userId } },
     })),
+    member: r.viaMany(blogUserPolicy, 'owner', 'members'),
   }),
   actions: {
-    read: { globalRoles: ['public'] },
+    read: { roles: ['member'], globalRoles: ['public'] },
     update: { roles: ['owner'], globalRoles: ['admin'] },
     delete: { roles: ['owner'], globalRoles: ['admin'] },
   },

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/utils/authorizers/create-model-policy.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/utils/authorizers/create-model-policy.ts
@@ -208,6 +208,14 @@ export function createModelPolicy<
         relation: link.relation,
       };
     },
+    viaMany: (target, role, relation) => {
+      if (!Object.hasOwn(target.roles, role)) {
+        throw new Error(
+          `r.viaMany('${role}', relation '${relation}'): target policy does not define role '${role}'.`,
+        );
+      }
+      return { kind: 'viaMany', target, role, relation };
+    },
     all: (parts) => {
       if (parts.length === 0) {
         throw new Error(
@@ -367,6 +375,9 @@ export function createModelPolicy<
       case 'via': {
         return node.target.roles[node.role].nestedWhere(ctx, node.relation);
       }
+      case 'viaMany': {
+        return node.target.roles[node.role].nestedWhereMany(ctx, node.relation);
+      }
       case 'where': {
         return assertNotUndefined(node.where(ctx), key);
       }
@@ -432,6 +443,21 @@ export function createModelPolicy<
         const targetIds = buildTargetIds(node.keys, model);
         if (targetIds === null) return false;
         return node.target.roles[node.role].checkById(ctx, targetIds);
+      }
+      case 'viaMany': {
+        // No local FK to read, so don't load or iterate the relation. Probe THIS
+        // model by its own id(s) with the same nested filter the where form
+        // uses — one query, and the two forms provably cannot drift.
+        const where = whereNode(ctx, node, key);
+        // No `true` guard here, unlike `where`/`userWhere`: `nestedWhereMany`
+        // folds an unrestricted target to `{ some: {} }`, so this can only be
+        // `false` or an object. Don't "restore" the guard — returning `true`
+        // would be exactly the vacuous grant that fold exists to prevent.
+        if (where === false) return false;
+        const ids = buildIds(model);
+        return cachedBoolean(ctx, roleCacheKey(ids, key), () =>
+          exists(ctx, ids, where),
+        );
       }
       case 'where': {
         const where = assertNotUndefined(node.where(ctx), key);
@@ -531,6 +557,14 @@ export function createModelPolicy<
         if (w === false) return false;
         // via is to-one only → direct nesting `{ relation: w }`, no `{ some }`.
         return { [relationField]: w };
+      },
+      nestedWhereMany: (ctx, relationField) => {
+        const w = roleWhere(ctx, roleName);
+        // Total deny stays a deny. But an UNRESTRICTED role must still require a
+        // related row — `{ some: {} }`, never `true`, or a host with no related
+        // rows would be granted the role vacuously.
+        if (w === false) return false;
+        return { [relationField]: { some: w === true ? {} : w } };
       },
     };
   }

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/utils/authorizers/types.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/utils/authorizers/types.ts
@@ -26,6 +26,37 @@ export type ToOneRelationKeys<M extends ModelPropName> = {
     : K;
 }[RelationKeys<M>];
 
+export type ToManyRelationKeys<M extends ModelPropName> = {
+  [K in RelationKeys<M>]: ObjectsOf<M>[K] extends readonly unknown[]
+    ? K
+    : never;
+}[RelationKeys<M>];
+
+/**
+ * The model a relation points at, as a `ModelPropName`. Every Prisma payload
+ * carries its own PascalCase `name` (`$BlogUserPayload` → `"BlogUser"`), so the
+ * relation's target model is recoverable from the type alone — uncapitalized
+ * back to the camelCase prop name policies are keyed by.
+ */
+type RelationModel<M extends ModelPropName, K extends RelationKeys<M>> = (
+  ObjectsOf<M>[K] extends readonly (infer E)[] ? E : ObjectsOf<M>[K]
+) extends { name: infer N extends string }
+  ? Uncapitalize<N> & ModelPropName
+  : never;
+
+/**
+ * To-many relations of `M` that point at model `TTarget` — the relations a
+ * `viaMany` delegating to a `TTarget` policy may legally name. Without this, any
+ * to-many relation type-checks and a mismatched pairing (`members` vs `posts`)
+ * silently filters the wrong model.
+ */
+export type ToManyRelationKeysOf<
+  M extends ModelPropName,
+  TTarget extends ModelPropName,
+> = {
+  [K in ToManyRelationKeys<M>]: RelationModel<M, K> extends TTarget ? K : never;
+}[ToManyRelationKeys<M>];
+
 export interface ViaLink<
   M extends ModelPropName,
   R extends ToOneRelationKeys<M>,
@@ -46,7 +77,10 @@ export type Exists<TModelName extends ModelPropName> = (
 export interface DelegationTarget<
   TIdField extends string = string,
   TRoleName extends string = string,
+  TModel extends ModelPropName = ModelPropName,
 > {
+  /** The model this policy governs — lets `viaMany` verify the relation matches. */
+  readonly model: TModel;
   idFields: readonly TIdField[];
   roles: Record<
     TRoleName,
@@ -56,6 +90,10 @@ export interface DelegationTarget<
         ids: Record<TIdField, string | number>,
       ) => Promise<boolean>;
       nestedWhere: (
+        ctx: ServiceContext,
+        relationField: string,
+      ) => WhereResult<ModelPropName>;
+      nestedWhereMany: (
         ctx: ServiceContext,
         relationField: string,
       ) => WhereResult<ModelPropName>;
@@ -116,6 +154,22 @@ export interface ViaRole<TModelName extends ModelPropName> {
   relation: string;
 }
 
+/**
+ * Existential delegation across a to-many relation: "I hold this role iff SOME
+ * related row grants `role`". The to-many counterpart of {@link ViaRole}.
+ *
+ * Unlike `via` there is no local FK to read off the row, so both the `where`
+ * and `check` forms go through `{ relation: { some: <target role where> } }` —
+ * `check` probes the host by its own id(s) with that same filter, so the two
+ * forms are one query and cannot drift.
+ */
+export interface ViaManyRole<TModelName extends ModelPropName> {
+  kind: 'viaMany';
+  target: DelegationTarget;
+  role: string;
+  relation: ToManyRelationKeys<TModelName>;
+}
+
 export interface HasRoleLeaf {
   kind: 'hasRole';
   roles: readonly string[];
@@ -148,6 +202,7 @@ export type RoleNode<TModelName extends ModelPropName> =
   | PredicateRole<TModelName>
   | UserWhereRole<TModelName>
   | ViaRole<TModelName>
+  | ViaManyRole<TModelName>
   | HasRoleLeaf
   | AuthenticatedLeaf
   | AllRole<TModelName>
@@ -188,6 +243,19 @@ export interface RoleBuilder<TModelName extends ModelPropName> {
     role: NoInfer<TTargetRoleName>,
     link: ViaLink<TModelName, R, TTargetIdField>,
   ) => ViaRole<TModelName>;
+  /**
+   * Existential delegation across a to-many relation — "SOME related row grants
+   * `role`". No `keys`: there is no local FK, so the relation name alone
+   * identifies the link. `relation` is constrained to relations that actually
+   * point at the target policy's model — but only when the target's model is
+   * statically known; a target passed as a bare `DelegationTarget` widens to
+   * `ModelPropName` and accepts any to-many relation.
+   */
+  viaMany: <TTargetRoleName extends string, TTargetModel extends ModelPropName>(
+    target: DelegationTarget<string, TTargetRoleName, TTargetModel>,
+    role: NoInfer<TTargetRoleName>,
+    relation: ToManyRelationKeysOf<TModelName, NoInfer<TTargetModel>>,
+  ) => ViaManyRole<TModelName>;
   hasRole: (...roles: string[]) => HasRoleLeaf;
   authenticated: () => AuthenticatedLeaf;
   all: (parts: NonEmptyArray<RoleNode<TModelName>>) => AllRole<TModelName>;
@@ -271,6 +339,16 @@ export interface PolicyRoleMembers<
     ids: Record<TIdField, string | number>,
   ) => Promise<void>;
   nestedWhere: (
+    ctx: ServiceContext,
+    relationField: string,
+  ) => WhereResult<TModelName>;
+  /**
+   * Existential form of {@link nestedWhere} — nests this role's where under a
+   * to-many relation as `{ relation: { some: … } }`. An unrestricted role folds
+   * to `{ some: {} }`, never `true`: a host with no related rows must not be
+   * granted the role vacuously.
+   */
+  nestedWhereMany: (
     ctx: ServiceContext,
     relationField: string,
   ) => WhereResult<TModelName>;

--- a/examples/blog-with-auth/apps/backend/src/modules/blogs/authorizers/blog.policy.ts
+++ b/examples/blog-with-auth/apps/backend/src/modules/blogs/authorizers/blog.policy.ts
@@ -1,6 +1,8 @@
 import { prisma } from '@src/services/prisma.js';
 import { createModelPolicy } from '@src/utils/authorizers/create-model-policy.js';
 
+import { blogUserPolicy } from './blog-user.policy.js';
+
 export const blogPolicy = createModelPolicy({
   model: 'blog',
   id: 'id',
@@ -10,9 +12,10 @@ export const blogPolicy = createModelPolicy({
     viewer: r.userWhere((session) => ({
       members: { some: { userId: session.userId } },
     })),
+    member: r.viaMany(blogUserPolicy, 'owner', 'members'),
   }),
   actions: {
-    read: { globalRoles: ['public'] },
+    read: { roles: ['member'], globalRoles: ['public'] },
     update: { roles: ['owner'], globalRoles: ['admin'] },
     delete: { roles: ['owner'], globalRoles: ['admin'] },
   },

--- a/examples/blog-with-auth/apps/backend/src/modules/blogs/authorizers/policy.unit.test.ts
+++ b/examples/blog-with-auth/apps/backend/src/modules/blogs/authorizers/policy.unit.test.ts
@@ -492,15 +492,174 @@ describe('r.match: runtime guard rejects a non-scalar value (bypassed TS)', asyn
 });
 
 describe('delegation: nestedWhere nests to-one directly', () => {
-  it('emits { relation: w } (via is to-one only — no { some } wrapping)', () => {
+  it('emits { relation: w } (r.via is to-one — no { some } wrapping)', () => {
     const ctx = makeCtx(USER_ID);
     // blog.owner.where(ctx) = { userId }
     const nested = blogPolicy.roles.owner.nestedWhere(ctx, 'blog');
     expect(nested).toEqual({ blog: { userId: USER_ID } });
-    // NOTE: to-many `via` is deliberately disallowed (type-level) — it can't be
-    // parent-key-cached, so it would just be a slower `r.where({rel:{some}})`.
-    // The `{ some }` form, when wanted, is authored directly as a relation
-    // predicate in `r.where`, not via delegation.
+  });
+});
+
+describe('r.viaMany — existential delegation across a to-many relation', () => {
+  // Host = Blog, target = BlogUser via Blog.members. Delegates to BlogUser's
+  // own `owner` role rather than restating its rule inline.
+  const blogViaMembers = createModelPolicy({
+    model: 'blog',
+    id: 'id',
+    delegate: prisma.blog,
+    roles: (r) => ({
+      member: r.viaMany(blogUserPolicy, 'owner', 'members'),
+    }),
+    actions: { read: { roles: ['member'] } },
+  });
+
+  it('where → { relation: { some: <target role where> } }', () => {
+    const ctx = makeCtx(USER_ID);
+    expect(blogViaMembers.actions.read.where(ctx)).toEqual({
+      members: { some: { userId: USER_ID } },
+    });
+  });
+
+  it('check probes the HOST by its own id with the nested filter (1 query, no relation load)', async () => {
+    const ctx = makeCtx(USER_ID);
+    blogCount.mockResolvedValueOnce(1);
+    const granted = await blogViaMembers.roles.member.check(ctx, {
+      id: 'blog-1',
+    } as never);
+    expect(granted).toBe(true);
+    // One probe on the host delegate, keyed by the host's own id — never an
+    // N+1 walk over `members`.
+    expect(blogCount).toHaveBeenCalledTimes(1);
+    expect(blogCount).toHaveBeenCalledWith({
+      where: {
+        AND: [{ id: 'blog-1' }, { members: { some: { userId: USER_ID } } }],
+      },
+    });
+  });
+
+  it('nestedWhereMany nests the target role under { some } directly', () => {
+    const ctx = makeCtx(USER_ID);
+    expect(blogUserPolicy.roles.owner.nestedWhereMany(ctx, 'members')).toEqual({
+      members: { some: { userId: USER_ID } },
+    });
+  });
+
+  it('caches per host id — two checks on the same row, one probe', async () => {
+    const ctx = makeCtx(USER_ID);
+    blogCount.mockResolvedValue(1);
+    const row = { id: 'blog-1' } as never;
+    await blogViaMembers.roles.member.check(ctx, row);
+    await blogViaMembers.roles.member.check(ctx, row);
+    expect(blogCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('composes inside r.some — grants via the viaMany branch', async () => {
+    const ctx = makeCtx(USER_ID);
+    const host = createModelPolicy({
+      model: 'blog',
+      id: 'id',
+      delegate: prisma.blog,
+      roles: (r) => ({
+        // First branch can't match (blog-1 is not owned by USER_ID here), so
+        // the grant must come from the viaMany branch.
+        readable: r.some([
+          r.match(() => ({ name: 'NOPE' })),
+          r.viaMany(blogUserPolicy, 'owner', 'members'),
+        ]),
+      }),
+      actions: { read: { roles: ['readable'] } },
+    });
+    blogCount.mockResolvedValueOnce(1);
+    await expect(
+      host.roles.readable.check(ctx, { id: 'blog-1', name: 'Blog' } as never),
+    ).resolves.toBe(true);
+  });
+
+  it('check denies when no related row grants the role', async () => {
+    const ctx = makeCtx(USER_ID);
+    blogCount.mockResolvedValueOnce(0);
+    await expect(
+      blogViaMembers.roles.member.check(ctx, { id: 'blog-1' } as never),
+    ).resolves.toBe(false);
+  });
+
+  it('UNRESTRICTED target role still requires a related row ({ some: {} }, never true)', () => {
+    // The subtle one: a host with NO related rows must not be granted the role
+    // vacuously. `true` would widen to allow-all; `{ some: {} }` keeps it
+    // existential.
+    const ctx = makeCtx(USER_ID);
+    const openTarget = createModelPolicy({
+      model: 'blogUser',
+      id: ['blogId', 'userId'],
+      delegate: prisma.blogUser,
+      roles: (r) => ({ anyone: r.authenticated() }),
+      actions: { read: { roles: ['anyone'] } },
+    });
+    const host = createModelPolicy({
+      model: 'blog',
+      id: 'id',
+      delegate: prisma.blog,
+      roles: (r) => ({ member: r.viaMany(openTarget, 'anyone', 'members') }),
+      actions: { read: { roles: ['member'] } },
+    });
+    expect(host.actions.read.where(ctx)).toEqual({ members: { some: {} } });
+  });
+
+  it('total-deny target role → denies outright (short-circuits, no query)', () => {
+    const ctx = makeCtx(USER_ID);
+    const denyTarget = createModelPolicy({
+      model: 'blogUser',
+      id: ['blogId', 'userId'],
+      delegate: prisma.blogUser,
+      roles: (r) => ({ nobody: r.where(() => false) }),
+      actions: { read: { roles: ['nobody'] } },
+    });
+    const host = createModelPolicy({
+      model: 'blog',
+      id: 'id',
+      delegate: prisma.blog,
+      roles: (r) => ({ member: r.viaMany(denyTarget, 'nobody', 'members') }),
+      actions: { read: { roles: ['member'] } },
+    });
+    // A total deny never reaches Prisma: the read filter throws rather than
+    // emitting a `{ some: false }` the query layer would have to interpret.
+    expect(() => host.actions.read.where(ctx)).toThrow(/Forbidden/);
+    expect(blogCount).not.toHaveBeenCalled();
+  });
+
+  it('rejects a relation pointing at a different model (compile time)', () => {
+    // `posts` is BlogPost[], but the target policy governs blogUser. The guard
+    // is the compiler: the `@ts-expect-error` fails the build if the mismatch
+    // ever starts type-checking again. The runtime assertion below only pins
+    // what it emits today — a wrong-model filter — which is why the compile-time
+    // constraint is the thing that matters.
+    const host = createModelPolicy({
+      model: 'blog',
+      id: 'id',
+      delegate: prisma.blog,
+      roles: (r) => ({
+        // @ts-expect-error 'posts' is not a to-many relation to blogUser
+        member: r.viaMany(blogUserPolicy, 'owner', 'posts'),
+      }),
+      actions: { read: { roles: ['member'] } },
+    });
+    expect(host.actions.read.where(makeCtx(USER_ID))).toEqual({
+      posts: { some: { userId: USER_ID } },
+    });
+  });
+
+  it('rejects a role the target policy does not define (construction time)', () => {
+    expect(() =>
+      createModelPolicy({
+        model: 'blog',
+        id: 'id',
+        delegate: prisma.blog,
+        roles: (r) => ({
+          member: r.viaMany(blogUserPolicy, 'nope' as never, 'members'),
+        }),
+        actions: { read: { roles: ['member'] } },
+      }),
+    ).toThrow(/does not define role 'nope'/);
   });
 });
 

--- a/examples/blog-with-auth/apps/backend/src/utils/authorizers/create-model-policy.ts
+++ b/examples/blog-with-auth/apps/backend/src/utils/authorizers/create-model-policy.ts
@@ -208,6 +208,14 @@ export function createModelPolicy<
         relation: link.relation,
       };
     },
+    viaMany: (target, role, relation) => {
+      if (!Object.hasOwn(target.roles, role)) {
+        throw new Error(
+          `r.viaMany('${role}', relation '${relation}'): target policy does not define role '${role}'.`,
+        );
+      }
+      return { kind: 'viaMany', target, role, relation };
+    },
     all: (parts) => {
       if (parts.length === 0) {
         throw new Error(
@@ -367,6 +375,9 @@ export function createModelPolicy<
       case 'via': {
         return node.target.roles[node.role].nestedWhere(ctx, node.relation);
       }
+      case 'viaMany': {
+        return node.target.roles[node.role].nestedWhereMany(ctx, node.relation);
+      }
       case 'where': {
         return assertNotUndefined(node.where(ctx), key);
       }
@@ -432,6 +443,21 @@ export function createModelPolicy<
         const targetIds = buildTargetIds(node.keys, model);
         if (targetIds === null) return false;
         return node.target.roles[node.role].checkById(ctx, targetIds);
+      }
+      case 'viaMany': {
+        // No local FK to read, so don't load or iterate the relation. Probe THIS
+        // model by its own id(s) with the same nested filter the where form
+        // uses — one query, and the two forms provably cannot drift.
+        const where = whereNode(ctx, node, key);
+        // No `true` guard here, unlike `where`/`userWhere`: `nestedWhereMany`
+        // folds an unrestricted target to `{ some: {} }`, so this can only be
+        // `false` or an object. Don't "restore" the guard — returning `true`
+        // would be exactly the vacuous grant that fold exists to prevent.
+        if (where === false) return false;
+        const ids = buildIds(model);
+        return cachedBoolean(ctx, roleCacheKey(ids, key), () =>
+          exists(ctx, ids, where),
+        );
       }
       case 'where': {
         const where = assertNotUndefined(node.where(ctx), key);
@@ -531,6 +557,14 @@ export function createModelPolicy<
         if (w === false) return false;
         // via is to-one only → direct nesting `{ relation: w }`, no `{ some }`.
         return { [relationField]: w };
+      },
+      nestedWhereMany: (ctx, relationField) => {
+        const w = roleWhere(ctx, roleName);
+        // Total deny stays a deny. But an UNRESTRICTED role must still require a
+        // related row — `{ some: {} }`, never `true`, or a host with no related
+        // rows would be granted the role vacuously.
+        if (w === false) return false;
+        return { [relationField]: { some: w === true ? {} : w } };
       },
     };
   }

--- a/examples/blog-with-auth/apps/backend/src/utils/authorizers/types.ts
+++ b/examples/blog-with-auth/apps/backend/src/utils/authorizers/types.ts
@@ -26,6 +26,37 @@ export type ToOneRelationKeys<M extends ModelPropName> = {
     : K;
 }[RelationKeys<M>];
 
+export type ToManyRelationKeys<M extends ModelPropName> = {
+  [K in RelationKeys<M>]: ObjectsOf<M>[K] extends readonly unknown[]
+    ? K
+    : never;
+}[RelationKeys<M>];
+
+/**
+ * The model a relation points at, as a `ModelPropName`. Every Prisma payload
+ * carries its own PascalCase `name` (`$BlogUserPayload` → `"BlogUser"`), so the
+ * relation's target model is recoverable from the type alone — uncapitalized
+ * back to the camelCase prop name policies are keyed by.
+ */
+type RelationModel<M extends ModelPropName, K extends RelationKeys<M>> = (
+  ObjectsOf<M>[K] extends readonly (infer E)[] ? E : ObjectsOf<M>[K]
+) extends { name: infer N extends string }
+  ? Uncapitalize<N> & ModelPropName
+  : never;
+
+/**
+ * To-many relations of `M` that point at model `TTarget` — the relations a
+ * `viaMany` delegating to a `TTarget` policy may legally name. Without this, any
+ * to-many relation type-checks and a mismatched pairing (`members` vs `posts`)
+ * silently filters the wrong model.
+ */
+export type ToManyRelationKeysOf<
+  M extends ModelPropName,
+  TTarget extends ModelPropName,
+> = {
+  [K in ToManyRelationKeys<M>]: RelationModel<M, K> extends TTarget ? K : never;
+}[ToManyRelationKeys<M>];
+
 export interface ViaLink<
   M extends ModelPropName,
   R extends ToOneRelationKeys<M>,
@@ -46,7 +77,10 @@ export type Exists<TModelName extends ModelPropName> = (
 export interface DelegationTarget<
   TIdField extends string = string,
   TRoleName extends string = string,
+  TModel extends ModelPropName = ModelPropName,
 > {
+  /** The model this policy governs — lets `viaMany` verify the relation matches. */
+  readonly model: TModel;
   idFields: readonly TIdField[];
   roles: Record<
     TRoleName,
@@ -56,6 +90,10 @@ export interface DelegationTarget<
         ids: Record<TIdField, string | number>,
       ) => Promise<boolean>;
       nestedWhere: (
+        ctx: ServiceContext,
+        relationField: string,
+      ) => WhereResult<ModelPropName>;
+      nestedWhereMany: (
         ctx: ServiceContext,
         relationField: string,
       ) => WhereResult<ModelPropName>;
@@ -116,6 +154,22 @@ export interface ViaRole<TModelName extends ModelPropName> {
   relation: string;
 }
 
+/**
+ * Existential delegation across a to-many relation: "I hold this role iff SOME
+ * related row grants `role`". The to-many counterpart of {@link ViaRole}.
+ *
+ * Unlike `via` there is no local FK to read off the row, so both the `where`
+ * and `check` forms go through `{ relation: { some: <target role where> } }` —
+ * `check` probes the host by its own id(s) with that same filter, so the two
+ * forms are one query and cannot drift.
+ */
+export interface ViaManyRole<TModelName extends ModelPropName> {
+  kind: 'viaMany';
+  target: DelegationTarget;
+  role: string;
+  relation: ToManyRelationKeys<TModelName>;
+}
+
 export interface HasRoleLeaf {
   kind: 'hasRole';
   roles: readonly string[];
@@ -148,6 +202,7 @@ export type RoleNode<TModelName extends ModelPropName> =
   | PredicateRole<TModelName>
   | UserWhereRole<TModelName>
   | ViaRole<TModelName>
+  | ViaManyRole<TModelName>
   | HasRoleLeaf
   | AuthenticatedLeaf
   | AllRole<TModelName>
@@ -188,6 +243,19 @@ export interface RoleBuilder<TModelName extends ModelPropName> {
     role: NoInfer<TTargetRoleName>,
     link: ViaLink<TModelName, R, TTargetIdField>,
   ) => ViaRole<TModelName>;
+  /**
+   * Existential delegation across a to-many relation — "SOME related row grants
+   * `role`". No `keys`: there is no local FK, so the relation name alone
+   * identifies the link. `relation` is constrained to relations that actually
+   * point at the target policy's model — but only when the target's model is
+   * statically known; a target passed as a bare `DelegationTarget` widens to
+   * `ModelPropName` and accepts any to-many relation.
+   */
+  viaMany: <TTargetRoleName extends string, TTargetModel extends ModelPropName>(
+    target: DelegationTarget<string, TTargetRoleName, TTargetModel>,
+    role: NoInfer<TTargetRoleName>,
+    relation: ToManyRelationKeysOf<TModelName, NoInfer<TTargetModel>>,
+  ) => ViaManyRole<TModelName>;
   hasRole: (...roles: string[]) => HasRoleLeaf;
   authenticated: () => AuthenticatedLeaf;
   all: (parts: NonEmptyArray<RoleNode<TModelName>>) => AllRole<TModelName>;
@@ -271,6 +339,16 @@ export interface PolicyRoleMembers<
     ids: Record<TIdField, string | number>,
   ) => Promise<void>;
   nestedWhere: (
+    ctx: ServiceContext,
+    relationField: string,
+  ) => WhereResult<TModelName>;
+  /**
+   * Existential form of {@link nestedWhere} — nests this role's where under a
+   * to-many relation as `{ relation: { some: … } }`. An unrestricted role folds
+   * to `{ some: {} }`, never `true`: a host with no related rows must not be
+   * granted the role vacuously.
+   */
+  nestedWhereMany: (
     ctx: ServiceContext,
     relationField: string,
   ) => WhereResult<TModelName>;

--- a/examples/blog-with-auth/baseplate/file-id-map.json
+++ b/examples/blog-with-auth/baseplate/file-id-map.json
@@ -11,6 +11,7 @@
   "@baseplate-dev/core-generators#node/root-readme:readme": "README.md",
   "@baseplate-dev/core-generators#node/turbo:turbo-config": "turbo.json",
   "@baseplate-dev/plugin-ai#dev-agents/core/dev-agents-config:agents-md": "AGENTS.md",
+  "@baseplate-dev/plugin-ai#dev-agents/core/dev-agents-config:authorization-md": ".agents/authorization.md",
   "@baseplate-dev/plugin-ai#dev-agents/core/dev-agents-config:baseplate-md": ".agents/baseplate.md",
   "@baseplate-dev/plugin-ai#dev-agents/core/dev-agents-config:claude-md": "CLAUDE.md"
 }

--- a/examples/blog-with-auth/baseplate/generated/.agents/authorization.md
+++ b/examples/blog-with-auth/baseplate/generated/.agents/authorization.md
@@ -1,0 +1,74 @@
+# Authorization
+
+Authorization is declared in the project definition and compiled into a policy
+per model. Nothing is hand-written in the generated policy files.
+
+Each model has an **authorizer** with named **roles**. A role is a predicate over
+a row ("is this principal the owner of this blog?"). Actions (`read`, `create`,
+`update`, `delete`) then grant access to a set of roles:
+
+- `roles` — instance roles, evaluated per row
+- `globalRoles` — principal-level roles (e.g. `admin`, `public`), row-independent
+
+A role compiles to both a boolean check (against a loaded row) and a Prisma
+`where` filter (to fan out over a list), derived from the same declaration — so
+"can I see this one?" and "which ones can I see?" can never disagree.
+
+## Authorization Expressions
+
+Each role's `expression` is a **JS-like boolean DSL** — it looks like TypeScript
+but only the following constructs are valid.
+
+| Construct                                    | Meaning                                                     |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| `model.<field> === userId`                   | Compare a field on the row to the principal (`!==` also OK) |
+| `model.<field> === 'literal'`                | Compare a field to a string/number/boolean literal          |
+| `isAuthenticated`                            | Any signed-in principal                                     |
+| `hasRole('admin')`                           | Principal holds a global role                               |
+| `hasSomeRole(['admin', 'editor'])`           | Principal holds any of several global roles                 |
+| `hasRole(model.<relation>, 'role')`          | **Delegate** to a role on a related model                   |
+| `hasSomeRole(model.<relation>, ['a', 'b'])`  | Delegate, matching any of several roles                     |
+| `exists(model.<relation>, { field: value })` | Some related record matches the conditions                  |
+| `all(model.<relation>, { field: value })`    | Every related record matches the conditions                 |
+| `&&`, `\|\|`                                 | Combine any of the above                                    |
+
+Available context: `model.<field>` (the row), `userId` and `isAuthenticated`
+(the principal). `userId` is the only auth property.
+
+**Delegation (`hasRole` with a relation)** is the main tool for reuse — instead
+of restating a parent's rule on the child, point at it:
+
+```js
+// BlogPost.owner — delegate to the Blog's own `owner` role (belongs-to)
+hasRole(model.blog, 'owner');
+
+// Blog.member — "some related BlogUser grants `owner`" (has-many)
+hasRole(model.members, 'owner');
+```
+
+Both relation directions work. A belongs-to relation delegates to the single
+related record; a has-many relation is **existential** — at least one related
+record must grant the role. A row with no related records is never granted the
+role, even if the delegated role is otherwise unrestricted.
+
+`exists`/`all` are the direct-predicate alternative when there is no role to
+reuse — they match on _fields_ of the related records, and require a has-many
+relation:
+
+```js
+// "I'm a member of this blog", stated inline rather than delegated
+exists(model.members, { userId: userId });
+```
+
+Prefer `hasRole(model.<relation>, ...)` when the related model already defines
+the role — it stays correct when that role's definition changes.
+
+## Editing authorization
+
+Roles live under a model's `authorizer.roles`; grants live on `graphql.queries`
+(read) and `service.{create,update,delete}`. Use `stage-patch-entity` on the
+`model` entity, then `show-draft` and `commit-draft`. The expression is
+validated on save — an unknown field, relation, or role surfaces as a warning
+rather than failing silently.
+
+See [baseplate.md](baseplate.md) for the general MCP workflow.

--- a/examples/blog-with-auth/baseplate/generated/.agents/baseplate.md
+++ b/examples/blog-with-auth/baseplate/generated/.agents/baseplate.md
@@ -68,6 +68,15 @@ Each model has:
 
 Common field types: `string`, `int`, `float`, `boolean`, `datetime`, `json`, `enum`
 
+## Authorization
+
+Models declare authorization as named roles whose `expression` is a JS-like
+boolean DSL (`model.userId === userId`, `hasRole(model.blog, 'owner')`,
+`exists(model.members, { userId: userId })`).
+
+See [authorization.md](authorization.md) for the full grammar, delegation across
+relations, and how to edit roles and grants.
+
 ## Tips
 
 - **Prefer MCP tools over editing `project-definition.json` directly** — The MCP server validates changes and maintains referential integrity

--- a/examples/blog-with-auth/baseplate/generated/AGENTS.md
+++ b/examples/blog-with-auth/baseplate/generated/AGENTS.md
@@ -57,3 +57,4 @@ This is a pnpm monorepo managed with Turborepo. Key directories:
 This project uses Baseplate for code generation. The project definition is stored in `baseplate/project-definition.json`.
 
 - See `.agents/baseplate.md` for how to use the Baseplate MCP server, modify data models, and manage plugins
+- See `.agents/authorization.md` for the authorization model and the expression DSL used by model roles

--- a/examples/blog-with-auth/baseplate/generated/CLAUDE.md
+++ b/examples/blog-with-auth/baseplate/generated/CLAUDE.md
@@ -6,4 +6,5 @@ See [AGENTS.md](AGENTS.md) for full project context, build commands, and convent
 
 - **Prefer Baseplate MCP tools** over editing `project-definition.json` directly — the MCP server validates changes and maintains referential integrity
 - See `.agents/baseplate.md` for MCP server usage, data model changes, and plugin management
+- See `.agents/authorization.md` for the authorization model and expression DSL
 - Generated code lives in `baseplate/generated/` directories — do not edit these files directly

--- a/examples/blog-with-auth/baseplate/project-definition.json
+++ b/examples/blog-with-auth/baseplate/project-definition.json
@@ -304,6 +304,11 @@
             "expression": "exists(model.members, { userId: userId })\n",
             "id": "model-authorizer-role:VosO0z22wzt0",
             "name": "viewer"
+          },
+          {
+            "expression": "hasRole(model.members, 'owner')",
+            "id": "model-authorizer-role:tyNu9gUr6iAH",
+            "name": "member"
           }
         ]
       },
@@ -320,6 +325,7 @@
         "queries": {
           "get": { "enabled": true },
           "globalRoles": ["public"],
+          "instanceRoles": ["member"],
           "list": { "enabled": true }
         }
       },

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/utils/authorizers/create-model-policy.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/utils/authorizers/create-model-policy.ts
@@ -208,6 +208,14 @@ export function createModelPolicy<
         relation: link.relation,
       };
     },
+    viaMany: (target, role, relation) => {
+      if (!Object.hasOwn(target.roles, role)) {
+        throw new Error(
+          `r.viaMany('${role}', relation '${relation}'): target policy does not define role '${role}'.`,
+        );
+      }
+      return { kind: 'viaMany', target, role, relation };
+    },
     all: (parts) => {
       if (parts.length === 0) {
         throw new Error(
@@ -367,6 +375,9 @@ export function createModelPolicy<
       case 'via': {
         return node.target.roles[node.role].nestedWhere(ctx, node.relation);
       }
+      case 'viaMany': {
+        return node.target.roles[node.role].nestedWhereMany(ctx, node.relation);
+      }
       case 'where': {
         return assertNotUndefined(node.where(ctx), key);
       }
@@ -432,6 +443,21 @@ export function createModelPolicy<
         const targetIds = buildTargetIds(node.keys, model);
         if (targetIds === null) return false;
         return node.target.roles[node.role].checkById(ctx, targetIds);
+      }
+      case 'viaMany': {
+        // No local FK to read, so don't load or iterate the relation. Probe THIS
+        // model by its own id(s) with the same nested filter the where form
+        // uses — one query, and the two forms provably cannot drift.
+        const where = whereNode(ctx, node, key);
+        // No `true` guard here, unlike `where`/`userWhere`: `nestedWhereMany`
+        // folds an unrestricted target to `{ some: {} }`, so this can only be
+        // `false` or an object. Don't "restore" the guard — returning `true`
+        // would be exactly the vacuous grant that fold exists to prevent.
+        if (where === false) return false;
+        const ids = buildIds(model);
+        return cachedBoolean(ctx, roleCacheKey(ids, key), () =>
+          exists(ctx, ids, where),
+        );
       }
       case 'where': {
         const where = assertNotUndefined(node.where(ctx), key);
@@ -531,6 +557,14 @@ export function createModelPolicy<
         if (w === false) return false;
         // via is to-one only → direct nesting `{ relation: w }`, no `{ some }`.
         return { [relationField]: w };
+      },
+      nestedWhereMany: (ctx, relationField) => {
+        const w = roleWhere(ctx, roleName);
+        // Total deny stays a deny. But an UNRESTRICTED role must still require a
+        // related row — `{ some: {} }`, never `true`, or a host with no related
+        // rows would be granted the role vacuously.
+        if (w === false) return false;
+        return { [relationField]: { some: w === true ? {} : w } };
       },
     };
   }

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/utils/authorizers/types.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/utils/authorizers/types.ts
@@ -26,6 +26,37 @@ export type ToOneRelationKeys<M extends ModelPropName> = {
     : K;
 }[RelationKeys<M>];
 
+export type ToManyRelationKeys<M extends ModelPropName> = {
+  [K in RelationKeys<M>]: ObjectsOf<M>[K] extends readonly unknown[]
+    ? K
+    : never;
+}[RelationKeys<M>];
+
+/**
+ * The model a relation points at, as a `ModelPropName`. Every Prisma payload
+ * carries its own PascalCase `name` (`$BlogUserPayload` → `"BlogUser"`), so the
+ * relation's target model is recoverable from the type alone — uncapitalized
+ * back to the camelCase prop name policies are keyed by.
+ */
+type RelationModel<M extends ModelPropName, K extends RelationKeys<M>> = (
+  ObjectsOf<M>[K] extends readonly (infer E)[] ? E : ObjectsOf<M>[K]
+) extends { name: infer N extends string }
+  ? Uncapitalize<N> & ModelPropName
+  : never;
+
+/**
+ * To-many relations of `M` that point at model `TTarget` — the relations a
+ * `viaMany` delegating to a `TTarget` policy may legally name. Without this, any
+ * to-many relation type-checks and a mismatched pairing (`members` vs `posts`)
+ * silently filters the wrong model.
+ */
+export type ToManyRelationKeysOf<
+  M extends ModelPropName,
+  TTarget extends ModelPropName,
+> = {
+  [K in ToManyRelationKeys<M>]: RelationModel<M, K> extends TTarget ? K : never;
+}[ToManyRelationKeys<M>];
+
 export interface ViaLink<
   M extends ModelPropName,
   R extends ToOneRelationKeys<M>,
@@ -46,7 +77,10 @@ export type Exists<TModelName extends ModelPropName> = (
 export interface DelegationTarget<
   TIdField extends string = string,
   TRoleName extends string = string,
+  TModel extends ModelPropName = ModelPropName,
 > {
+  /** The model this policy governs — lets `viaMany` verify the relation matches. */
+  readonly model: TModel;
   idFields: readonly TIdField[];
   roles: Record<
     TRoleName,
@@ -56,6 +90,10 @@ export interface DelegationTarget<
         ids: Record<TIdField, string | number>,
       ) => Promise<boolean>;
       nestedWhere: (
+        ctx: ServiceContext,
+        relationField: string,
+      ) => WhereResult<ModelPropName>;
+      nestedWhereMany: (
         ctx: ServiceContext,
         relationField: string,
       ) => WhereResult<ModelPropName>;
@@ -116,6 +154,22 @@ export interface ViaRole<TModelName extends ModelPropName> {
   relation: string;
 }
 
+/**
+ * Existential delegation across a to-many relation: "I hold this role iff SOME
+ * related row grants `role`". The to-many counterpart of {@link ViaRole}.
+ *
+ * Unlike `via` there is no local FK to read off the row, so both the `where`
+ * and `check` forms go through `{ relation: { some: <target role where> } }` —
+ * `check` probes the host by its own id(s) with that same filter, so the two
+ * forms are one query and cannot drift.
+ */
+export interface ViaManyRole<TModelName extends ModelPropName> {
+  kind: 'viaMany';
+  target: DelegationTarget;
+  role: string;
+  relation: ToManyRelationKeys<TModelName>;
+}
+
 export interface HasRoleLeaf {
   kind: 'hasRole';
   roles: readonly string[];
@@ -148,6 +202,7 @@ export type RoleNode<TModelName extends ModelPropName> =
   | PredicateRole<TModelName>
   | UserWhereRole<TModelName>
   | ViaRole<TModelName>
+  | ViaManyRole<TModelName>
   | HasRoleLeaf
   | AuthenticatedLeaf
   | AllRole<TModelName>
@@ -188,6 +243,19 @@ export interface RoleBuilder<TModelName extends ModelPropName> {
     role: NoInfer<TTargetRoleName>,
     link: ViaLink<TModelName, R, TTargetIdField>,
   ) => ViaRole<TModelName>;
+  /**
+   * Existential delegation across a to-many relation — "SOME related row grants
+   * `role`". No `keys`: there is no local FK, so the relation name alone
+   * identifies the link. `relation` is constrained to relations that actually
+   * point at the target policy's model — but only when the target's model is
+   * statically known; a target passed as a bare `DelegationTarget` widens to
+   * `ModelPropName` and accepts any to-many relation.
+   */
+  viaMany: <TTargetRoleName extends string, TTargetModel extends ModelPropName>(
+    target: DelegationTarget<string, TTargetRoleName, TTargetModel>,
+    role: NoInfer<TTargetRoleName>,
+    relation: ToManyRelationKeysOf<TModelName, NoInfer<TTargetModel>>,
+  ) => ViaManyRole<TModelName>;
   hasRole: (...roles: string[]) => HasRoleLeaf;
   authenticated: () => AuthenticatedLeaf;
   all: (parts: NonEmptyArray<RoleNode<TModelName>>) => AllRole<TModelName>;
@@ -271,6 +339,16 @@ export interface PolicyRoleMembers<
     ids: Record<TIdField, string | number>,
   ) => Promise<void>;
   nestedWhere: (
+    ctx: ServiceContext,
+    relationField: string,
+  ) => WhereResult<TModelName>;
+  /**
+   * Existential form of {@link nestedWhere} — nests this role's where under a
+   * to-many relation as `{ relation: { some: … } }`. An unrestricted role folds
+   * to `{ some: {} }`, never `true`: a host with no related rows must not be
+   * granted the role vacuously.
+   */
+  nestedWhereMany: (
     ctx: ServiceContext,
     relationField: string,
   ) => WhereResult<TModelName>;

--- a/examples/todo-with-better-auth/apps/backend/src/utils/authorizers/create-model-policy.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/utils/authorizers/create-model-policy.ts
@@ -208,6 +208,14 @@ export function createModelPolicy<
         relation: link.relation,
       };
     },
+    viaMany: (target, role, relation) => {
+      if (!Object.hasOwn(target.roles, role)) {
+        throw new Error(
+          `r.viaMany('${role}', relation '${relation}'): target policy does not define role '${role}'.`,
+        );
+      }
+      return { kind: 'viaMany', target, role, relation };
+    },
     all: (parts) => {
       if (parts.length === 0) {
         throw new Error(
@@ -367,6 +375,9 @@ export function createModelPolicy<
       case 'via': {
         return node.target.roles[node.role].nestedWhere(ctx, node.relation);
       }
+      case 'viaMany': {
+        return node.target.roles[node.role].nestedWhereMany(ctx, node.relation);
+      }
       case 'where': {
         return assertNotUndefined(node.where(ctx), key);
       }
@@ -432,6 +443,21 @@ export function createModelPolicy<
         const targetIds = buildTargetIds(node.keys, model);
         if (targetIds === null) return false;
         return node.target.roles[node.role].checkById(ctx, targetIds);
+      }
+      case 'viaMany': {
+        // No local FK to read, so don't load or iterate the relation. Probe THIS
+        // model by its own id(s) with the same nested filter the where form
+        // uses — one query, and the two forms provably cannot drift.
+        const where = whereNode(ctx, node, key);
+        // No `true` guard here, unlike `where`/`userWhere`: `nestedWhereMany`
+        // folds an unrestricted target to `{ some: {} }`, so this can only be
+        // `false` or an object. Don't "restore" the guard — returning `true`
+        // would be exactly the vacuous grant that fold exists to prevent.
+        if (where === false) return false;
+        const ids = buildIds(model);
+        return cachedBoolean(ctx, roleCacheKey(ids, key), () =>
+          exists(ctx, ids, where),
+        );
       }
       case 'where': {
         const where = assertNotUndefined(node.where(ctx), key);
@@ -531,6 +557,14 @@ export function createModelPolicy<
         if (w === false) return false;
         // via is to-one only → direct nesting `{ relation: w }`, no `{ some }`.
         return { [relationField]: w };
+      },
+      nestedWhereMany: (ctx, relationField) => {
+        const w = roleWhere(ctx, roleName);
+        // Total deny stays a deny. But an UNRESTRICTED role must still require a
+        // related row — `{ some: {} }`, never `true`, or a host with no related
+        // rows would be granted the role vacuously.
+        if (w === false) return false;
+        return { [relationField]: { some: w === true ? {} : w } };
       },
     };
   }

--- a/examples/todo-with-better-auth/apps/backend/src/utils/authorizers/types.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/utils/authorizers/types.ts
@@ -26,6 +26,37 @@ export type ToOneRelationKeys<M extends ModelPropName> = {
     : K;
 }[RelationKeys<M>];
 
+export type ToManyRelationKeys<M extends ModelPropName> = {
+  [K in RelationKeys<M>]: ObjectsOf<M>[K] extends readonly unknown[]
+    ? K
+    : never;
+}[RelationKeys<M>];
+
+/**
+ * The model a relation points at, as a `ModelPropName`. Every Prisma payload
+ * carries its own PascalCase `name` (`$BlogUserPayload` → `"BlogUser"`), so the
+ * relation's target model is recoverable from the type alone — uncapitalized
+ * back to the camelCase prop name policies are keyed by.
+ */
+type RelationModel<M extends ModelPropName, K extends RelationKeys<M>> = (
+  ObjectsOf<M>[K] extends readonly (infer E)[] ? E : ObjectsOf<M>[K]
+) extends { name: infer N extends string }
+  ? Uncapitalize<N> & ModelPropName
+  : never;
+
+/**
+ * To-many relations of `M` that point at model `TTarget` — the relations a
+ * `viaMany` delegating to a `TTarget` policy may legally name. Without this, any
+ * to-many relation type-checks and a mismatched pairing (`members` vs `posts`)
+ * silently filters the wrong model.
+ */
+export type ToManyRelationKeysOf<
+  M extends ModelPropName,
+  TTarget extends ModelPropName,
+> = {
+  [K in ToManyRelationKeys<M>]: RelationModel<M, K> extends TTarget ? K : never;
+}[ToManyRelationKeys<M>];
+
 export interface ViaLink<
   M extends ModelPropName,
   R extends ToOneRelationKeys<M>,
@@ -46,7 +77,10 @@ export type Exists<TModelName extends ModelPropName> = (
 export interface DelegationTarget<
   TIdField extends string = string,
   TRoleName extends string = string,
+  TModel extends ModelPropName = ModelPropName,
 > {
+  /** The model this policy governs — lets `viaMany` verify the relation matches. */
+  readonly model: TModel;
   idFields: readonly TIdField[];
   roles: Record<
     TRoleName,
@@ -56,6 +90,10 @@ export interface DelegationTarget<
         ids: Record<TIdField, string | number>,
       ) => Promise<boolean>;
       nestedWhere: (
+        ctx: ServiceContext,
+        relationField: string,
+      ) => WhereResult<ModelPropName>;
+      nestedWhereMany: (
         ctx: ServiceContext,
         relationField: string,
       ) => WhereResult<ModelPropName>;
@@ -116,6 +154,22 @@ export interface ViaRole<TModelName extends ModelPropName> {
   relation: string;
 }
 
+/**
+ * Existential delegation across a to-many relation: "I hold this role iff SOME
+ * related row grants `role`". The to-many counterpart of {@link ViaRole}.
+ *
+ * Unlike `via` there is no local FK to read off the row, so both the `where`
+ * and `check` forms go through `{ relation: { some: <target role where> } }` —
+ * `check` probes the host by its own id(s) with that same filter, so the two
+ * forms are one query and cannot drift.
+ */
+export interface ViaManyRole<TModelName extends ModelPropName> {
+  kind: 'viaMany';
+  target: DelegationTarget;
+  role: string;
+  relation: ToManyRelationKeys<TModelName>;
+}
+
 export interface HasRoleLeaf {
   kind: 'hasRole';
   roles: readonly string[];
@@ -148,6 +202,7 @@ export type RoleNode<TModelName extends ModelPropName> =
   | PredicateRole<TModelName>
   | UserWhereRole<TModelName>
   | ViaRole<TModelName>
+  | ViaManyRole<TModelName>
   | HasRoleLeaf
   | AuthenticatedLeaf
   | AllRole<TModelName>
@@ -188,6 +243,19 @@ export interface RoleBuilder<TModelName extends ModelPropName> {
     role: NoInfer<TTargetRoleName>,
     link: ViaLink<TModelName, R, TTargetIdField>,
   ) => ViaRole<TModelName>;
+  /**
+   * Existential delegation across a to-many relation — "SOME related row grants
+   * `role`". No `keys`: there is no local FK, so the relation name alone
+   * identifies the link. `relation` is constrained to relations that actually
+   * point at the target policy's model — but only when the target's model is
+   * statically known; a target passed as a bare `DelegationTarget` widens to
+   * `ModelPropName` and accepts any to-many relation.
+   */
+  viaMany: <TTargetRoleName extends string, TTargetModel extends ModelPropName>(
+    target: DelegationTarget<string, TTargetRoleName, TTargetModel>,
+    role: NoInfer<TTargetRoleName>,
+    relation: ToManyRelationKeysOf<TModelName, NoInfer<TTargetModel>>,
+  ) => ViaManyRole<TModelName>;
   hasRole: (...roles: string[]) => HasRoleLeaf;
   authenticated: () => AuthenticatedLeaf;
   all: (parts: NonEmptyArray<RoleNode<TModelName>>) => AllRole<TModelName>;
@@ -271,6 +339,16 @@ export interface PolicyRoleMembers<
     ids: Record<TIdField, string | number>,
   ) => Promise<void>;
   nestedWhere: (
+    ctx: ServiceContext,
+    relationField: string,
+  ) => WhereResult<TModelName>;
+  /**
+   * Existential form of {@link nestedWhere} — nests this role's where under a
+   * to-many relation as `{ relation: { some: … } }`. An unrestricted role folds
+   * to `{ some: {} }`, never `true`: a host with no related rows must not be
+   * granted the role vacuously.
+   */
+  nestedWhereMany: (
     ctx: ServiceContext,
     relationField: string,
   ) => WhereResult<TModelName>;

--- a/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/templates/src/utils/authorizers/create-model-policy.ts
+++ b/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/templates/src/utils/authorizers/create-model-policy.ts
@@ -210,6 +210,14 @@ export function createModelPolicy<
         relation: link.relation,
       };
     },
+    viaMany: (target, role, relation) => {
+      if (!Object.hasOwn(target.roles, role)) {
+        throw new Error(
+          `r.viaMany('${role}', relation '${relation}'): target policy does not define role '${role}'.`,
+        );
+      }
+      return { kind: 'viaMany', target, role, relation };
+    },
     all: (parts) => {
       if (parts.length === 0) {
         throw new Error(
@@ -369,6 +377,9 @@ export function createModelPolicy<
       case 'via': {
         return node.target.roles[node.role].nestedWhere(ctx, node.relation);
       }
+      case 'viaMany': {
+        return node.target.roles[node.role].nestedWhereMany(ctx, node.relation);
+      }
       case 'where': {
         return assertNotUndefined(node.where(ctx), key);
       }
@@ -434,6 +445,21 @@ export function createModelPolicy<
         const targetIds = buildTargetIds(node.keys, model);
         if (targetIds === null) return false;
         return node.target.roles[node.role].checkById(ctx, targetIds);
+      }
+      case 'viaMany': {
+        // No local FK to read, so don't load or iterate the relation. Probe THIS
+        // model by its own id(s) with the same nested filter the where form
+        // uses — one query, and the two forms provably cannot drift.
+        const where = whereNode(ctx, node, key);
+        // No `true` guard here, unlike `where`/`userWhere`: `nestedWhereMany`
+        // folds an unrestricted target to `{ some: {} }`, so this can only be
+        // `false` or an object. Don't "restore" the guard — returning `true`
+        // would be exactly the vacuous grant that fold exists to prevent.
+        if (where === false) return false;
+        const ids = buildIds(model);
+        return cachedBoolean(ctx, roleCacheKey(ids, key), () =>
+          exists(ctx, ids, where),
+        );
       }
       case 'where': {
         const where = assertNotUndefined(node.where(ctx), key);
@@ -533,6 +559,14 @@ export function createModelPolicy<
         if (w === false) return false;
         // via is to-one only → direct nesting `{ relation: w }`, no `{ some }`.
         return { [relationField]: w };
+      },
+      nestedWhereMany: (ctx, relationField) => {
+        const w = roleWhere(ctx, roleName);
+        // Total deny stays a deny. But an UNRESTRICTED role must still require a
+        // related row — `{ some: {} }`, never `true`, or a host with no related
+        // rows would be granted the role vacuously.
+        if (w === false) return false;
+        return { [relationField]: { some: w === true ? {} : w } };
       },
     };
   }

--- a/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/templates/src/utils/authorizers/types.ts
+++ b/packages/fastify-generators/src/generators/prisma/prisma-authorizer-utils/templates/src/utils/authorizers/types.ts
@@ -27,6 +27,37 @@ export type ToOneRelationKeys<M extends ModelPropName> = {
     : K;
 }[RelationKeys<M>];
 
+export type ToManyRelationKeys<M extends ModelPropName> = {
+  [K in RelationKeys<M>]: ObjectsOf<M>[K] extends readonly unknown[]
+    ? K
+    : never;
+}[RelationKeys<M>];
+
+/**
+ * The model a relation points at, as a `ModelPropName`. Every Prisma payload
+ * carries its own PascalCase `name` (`$BlogUserPayload` → `"BlogUser"`), so the
+ * relation's target model is recoverable from the type alone — uncapitalized
+ * back to the camelCase prop name policies are keyed by.
+ */
+type RelationModel<M extends ModelPropName, K extends RelationKeys<M>> = (
+  ObjectsOf<M>[K] extends readonly (infer E)[] ? E : ObjectsOf<M>[K]
+) extends { name: infer N extends string }
+  ? Uncapitalize<N> & ModelPropName
+  : never;
+
+/**
+ * To-many relations of `M` that point at model `TTarget` — the relations a
+ * `viaMany` delegating to a `TTarget` policy may legally name. Without this, any
+ * to-many relation type-checks and a mismatched pairing (`members` vs `posts`)
+ * silently filters the wrong model.
+ */
+export type ToManyRelationKeysOf<
+  M extends ModelPropName,
+  TTarget extends ModelPropName,
+> = {
+  [K in ToManyRelationKeys<M>]: RelationModel<M, K> extends TTarget ? K : never;
+}[ToManyRelationKeys<M>];
+
 export interface ViaLink<
   M extends ModelPropName,
   R extends ToOneRelationKeys<M>,
@@ -47,7 +78,10 @@ export type Exists<TModelName extends ModelPropName> = (
 export interface DelegationTarget<
   TIdField extends string = string,
   TRoleName extends string = string,
+  TModel extends ModelPropName = ModelPropName,
 > {
+  /** The model this policy governs — lets `viaMany` verify the relation matches. */
+  readonly model: TModel;
   idFields: readonly TIdField[];
   roles: Record<
     TRoleName,
@@ -57,6 +91,10 @@ export interface DelegationTarget<
         ids: Record<TIdField, string | number>,
       ) => Promise<boolean>;
       nestedWhere: (
+        ctx: ServiceContext,
+        relationField: string,
+      ) => WhereResult<ModelPropName>;
+      nestedWhereMany: (
         ctx: ServiceContext,
         relationField: string,
       ) => WhereResult<ModelPropName>;
@@ -117,6 +155,22 @@ export interface ViaRole<TModelName extends ModelPropName> {
   relation: string;
 }
 
+/**
+ * Existential delegation across a to-many relation: "I hold this role iff SOME
+ * related row grants `role`". The to-many counterpart of {@link ViaRole}.
+ *
+ * Unlike `via` there is no local FK to read off the row, so both the `where`
+ * and `check` forms go through `{ relation: { some: <target role where> } }` —
+ * `check` probes the host by its own id(s) with that same filter, so the two
+ * forms are one query and cannot drift.
+ */
+export interface ViaManyRole<TModelName extends ModelPropName> {
+  kind: 'viaMany';
+  target: DelegationTarget;
+  role: string;
+  relation: ToManyRelationKeys<TModelName>;
+}
+
 export interface HasRoleLeaf {
   kind: 'hasRole';
   roles: readonly string[];
@@ -149,6 +203,7 @@ export type RoleNode<TModelName extends ModelPropName> =
   | PredicateRole<TModelName>
   | UserWhereRole<TModelName>
   | ViaRole<TModelName>
+  | ViaManyRole<TModelName>
   | HasRoleLeaf
   | AuthenticatedLeaf
   | AllRole<TModelName>
@@ -189,6 +244,19 @@ export interface RoleBuilder<TModelName extends ModelPropName> {
     role: NoInfer<TTargetRoleName>,
     link: ViaLink<TModelName, R, TTargetIdField>,
   ) => ViaRole<TModelName>;
+  /**
+   * Existential delegation across a to-many relation — "SOME related row grants
+   * `role`". No `keys`: there is no local FK, so the relation name alone
+   * identifies the link. `relation` is constrained to relations that actually
+   * point at the target policy's model — but only when the target's model is
+   * statically known; a target passed as a bare `DelegationTarget` widens to
+   * `ModelPropName` and accepts any to-many relation.
+   */
+  viaMany: <TTargetRoleName extends string, TTargetModel extends ModelPropName>(
+    target: DelegationTarget<string, TTargetRoleName, TTargetModel>,
+    role: NoInfer<TTargetRoleName>,
+    relation: ToManyRelationKeysOf<TModelName, NoInfer<TTargetModel>>,
+  ) => ViaManyRole<TModelName>;
   hasRole: (...roles: string[]) => HasRoleLeaf;
   authenticated: () => AuthenticatedLeaf;
   all: (parts: NonEmptyArray<RoleNode<TModelName>>) => AllRole<TModelName>;
@@ -272,6 +340,16 @@ export interface PolicyRoleMembers<
     ids: Record<TIdField, string | number>,
   ) => Promise<void>;
   nestedWhere: (
+    ctx: ServiceContext,
+    relationField: string,
+  ) => WhereResult<TModelName>;
+  /**
+   * Existential form of {@link nestedWhere} — nests this role's where under a
+   * to-many relation as `{ relation: { some: … } }`. An unrestricted role folds
+   * to `{ some: {} }`, never `true`: a host with no related rows must not be
+   * granted the role vacuously.
+   */
+  nestedWhereMany: (
     ctx: ServiceContext,
     relationField: string,
   ) => WhereResult<TModelName>;

--- a/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-parser.ts
+++ b/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-parser.ts
@@ -57,6 +57,12 @@ export class AuthorizerExpressionParser extends RefExpressionParser<
 > {
   readonly name = 'authorizer-expression';
 
+  readonly description =
+    'JS-like boolean DSL over `model.<field>`, `userId`, and `isAuthenticated` — ' +
+    "e.g. `model.userId === userId`, `hasRole(model.blog, 'owner')`, " +
+    '`exists(model.members, { userId: userId })`. See .agents/authorization.md ' +
+    'for the full grammar.';
+
   /**
    * Creates a Zod schema for validating expression strings.
    * Requires a non-empty string value.

--- a/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-validator.unit.test.ts
+++ b/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-validator.unit.test.ts
@@ -471,6 +471,16 @@ describe('validateAuthorizerExpression', () => {
             direction: 'local' as const,
           },
         ],
+        // Reverse (has-many) relation: TodoItem's FK points at Todo. Roles come
+        // from the FK holder, which is what hasRole delegates to.
+        [
+          'items',
+          {
+            foreignModelName: 'TodoItem',
+            foreignAuthorizerRoleNames: new Set(['assignee']),
+            direction: 'foreign' as const,
+          },
+        ],
       ]),
     };
 
@@ -493,6 +503,53 @@ describe('validateAuthorizerExpression', () => {
       );
 
       expect(warnings).toEqual([]);
+    });
+
+    it('should validate nested hasRole on a reverse (has-many) relation', () => {
+      // ENG-1211: hasRole delegates across BOTH directions — a has-many
+      // relation means "SOME related row grants the role" (lowered to
+      // r.viaMany). Only exists()/all() are direction-restricted.
+      const ast: NestedHasRoleNode = {
+        type: 'nestedHasRole',
+        relationName: 'items',
+        relationStart: 8,
+        relationEnd: 19,
+        role: 'assignee',
+        roleStart: 21,
+        roleEnd: 31,
+      };
+
+      const warnings = validateAuthorizerExpression(
+        ast,
+        modelContextWithRelations,
+        defaultPluginStore,
+        defaultDefinition,
+      );
+
+      expect(warnings).toEqual([]);
+    });
+
+    it('should warn for an unknown role on a reverse (has-many) relation', () => {
+      const ast: NestedHasRoleNode = {
+        type: 'nestedHasRole',
+        relationName: 'items',
+        relationStart: 8,
+        relationEnd: 19,
+        role: 'nope',
+        roleStart: 21,
+        roleEnd: 27,
+      };
+
+      const warnings = validateAuthorizerExpression(
+        ast,
+        modelContextWithRelations,
+        defaultPluginStore,
+        defaultDefinition,
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toContain("'nope'");
+      expect(warnings[0].message).toContain('TodoItem');
     });
 
     it('should warn for nonexistent relation', () => {

--- a/packages/project-builder-lib/src/references/expression-types.ts
+++ b/packages/project-builder-lib/src/references/expression-types.ts
@@ -125,6 +125,13 @@ export abstract class RefExpressionParser<
   abstract readonly name: string;
 
   /**
+   * One-line summary of the expression language, surfaced to MCP consumers by
+   * `get-entity-schema` so an agent editing this field knows it is a DSL rather
+   * than free-form text. Point at fuller docs rather than restating the grammar.
+   */
+  readonly description?: string;
+
+  /**
    * Creates a new Zod schema instance for validating the expression value.
    *
    * @returns A fresh Zod schema that validates the raw expression value

--- a/packages/project-builder-lib/src/schema/models/authorizer/authorizer.ts
+++ b/packages/project-builder-lib/src/schema/models/authorizer/authorizer.ts
@@ -29,16 +29,20 @@ export const createAuthorizerRoleSchema = definitionSchemaWithSlots(
          */
         name: VALIDATORS.CAMEL_CASE_STRING,
         /**
-         * TypeScript expression that evaluates to a boolean.
+         * Authorization expression — a JS-like boolean DSL, not arbitrary
+         * TypeScript. See `.agents/authorization.md` for the full grammar.
          *
-         * Available context variables:
-         * - `model` - The model instance being authorized
-         * - `userId` - The authenticated user's ID (implicit auth context)
-         * - `hasRole()` / `hasSomeRole()` - Role checking functions
+         * Available context:
+         * - `model.<field>` — the row being authorized (scalars and relations)
+         * - `userId` / `isAuthenticated` — the principal
+         * - `hasRole()` / `hasSomeRole()` — global roles, or role delegation
+         *   across a relation in the two-argument form
+         * - `exists()` / `all()` — quantify over a has-many relation
          *
-         * @example 'model.id === userId'
-         * @example 'hasRole("admin")'
-         * @example 'model.authorId === userId || hasRole("admin")'
+         * @example 'model.userId === userId'
+         * @example "hasRole('admin')"
+         * @example "hasRole(model.blog, 'owner')"
+         * @example 'exists(model.members, { userId: userId })'
          */
         expression: ctx.withExpression(authorizerExpressionRef, {
           model: modelSlot,

--- a/packages/project-builder-server/src/actions/definition/build-ts-description-registry.ts
+++ b/packages/project-builder-server/src/actions/definition/build-ts-description-registry.ts
@@ -40,6 +40,14 @@ export function buildTsDescriptionRegistry(
           descriptions.push(
             `@entity(${meta.type.name}) - Entity type '${meta.type.name}'. IDs are auto-generated; omit the id field.`,
           );
+        } else if (meta.kind === 'expression') {
+          // Expression fields are a DSL, not free-form text — say so, and let
+          // the parser point at its own docs.
+          descriptions.push(
+            `@expression(${meta.parser.name}) - A structured expression, not free-form text.${
+              meta.parser.description ? ` ${meta.parser.description}` : ''
+            }`,
+          );
         }
       }
 

--- a/packages/project-builder-server/src/actions/definition/build-ts-description-registry.ts
+++ b/packages/project-builder-server/src/actions/definition/build-ts-description-registry.ts
@@ -58,7 +58,11 @@ export function buildTsDescriptionRegistry(
 
             break;
           }
-          // No default
+          case 'ref-context': {
+            // Slot-scoping machinery, not a user-facing annotation — nothing
+            // to render.
+            break;
+          }
         }
       }
 

--- a/packages/project-builder-server/src/actions/definition/build-ts-description-registry.ts
+++ b/packages/project-builder-server/src/actions/definition/build-ts-description-registry.ts
@@ -32,22 +32,33 @@ export function buildTsDescriptionRegistry(
       // Check for ref/entity metadata from definitionRefRegistry
       const metaList = definitionRefRegistry.getAll(visitedSchema);
       for (const meta of metaList) {
-        if (meta.kind === 'reference') {
-          descriptions.push(
-            `@ref(${meta.type.name}) - Reference to a '${meta.type.name}' entity. Use entity name, not ID.`,
-          );
-        } else if (meta.kind === 'entity') {
-          descriptions.push(
-            `@entity(${meta.type.name}) - Entity type '${meta.type.name}'. IDs are auto-generated; omit the id field.`,
-          );
-        } else if (meta.kind === 'expression') {
-          // Expression fields are a DSL, not free-form text — say so, and let
-          // the parser point at its own docs.
-          descriptions.push(
-            `@expression(${meta.parser.name}) - A structured expression, not free-form text.${
-              meta.parser.description ? ` ${meta.parser.description}` : ''
-            }`,
-          );
+        switch (meta.kind) {
+          case 'reference': {
+            descriptions.push(
+              `@ref(${meta.type.name}) - Reference to a '${meta.type.name}' entity. Use entity name, not ID.`,
+            );
+
+            break;
+          }
+          case 'entity': {
+            descriptions.push(
+              `@entity(${meta.type.name}) - Entity type '${meta.type.name}'. IDs are auto-generated; omit the id field.`,
+            );
+
+            break;
+          }
+          case 'expression': {
+            // Expression fields are a DSL, not free-form text — say so, and let
+            // the parser point at its own docs.
+            descriptions.push(
+              `@expression(${meta.parser.name}) - A structured expression, not free-form text.${
+                meta.parser.description ? ` ${meta.parser.description}` : ''
+              }`,
+            );
+
+            break;
+          }
+          // No default
         }
       }
 

--- a/packages/project-builder-server/src/compiler/backend/policy-compiler.ts
+++ b/packages/project-builder-server/src/compiler/backend/policy-compiler.ts
@@ -26,7 +26,7 @@ import { lowercaseFirstChar } from '@baseplate-dev/utils';
 import type { BackendAppEntryBuilder } from '../app-entry-builder.js';
 import type {
   PolicyLoweringContext,
-  ResolvedViaLink,
+  ResolvedDelegationLink,
 } from './policy-lowering.js';
 import type {
   QueryFilterCodeContext,
@@ -53,54 +53,86 @@ interface LoweredRole {
 }
 
 /**
- * Resolve `via` delegation links for a model's nested role refs. Mirrors the old
+ * Resolve delegation links for a model's nested role refs. Mirrors the old
  * authorizer resolution, but the target is the parent POLICY var (`blogPolicy`),
  * not an authorizer var.
+ *
+ * Searches local relations first (FK on this model → `r.via`), then reverse
+ * relations (FK on another model pointing here via `foreignRelationName` →
+ * `r.viaMany`). Local-first precedence matches `buildModelExpressionContext`,
+ * so a name collision resolves the same way the editor validated it.
  */
 function resolveViaLinks(
   appBuilder: BackendAppEntryBuilder,
   model: ModelConfig,
   nestedRoleRefs: { relationName: string }[],
-): { resolvedVia: Map<string, ResolvedViaLink>; foreignModelNames: string[] } {
-  const resolvedVia = new Map<string, ResolvedViaLink>();
+): {
+  resolvedVia: Map<string, ResolvedDelegationLink>;
+  foreignModelNames: string[];
+} {
+  const resolvedVia = new Map<string, ResolvedDelegationLink>();
   const foreignModelNames: string[] = [];
+
+  function trackForeignModel(name: string): void {
+    if (!foreignModelNames.includes(name)) {
+      foreignModelNames.push(name);
+    }
+  }
 
   for (const { relationName } of nestedRoleRefs) {
     if (resolvedVia.has(relationName)) continue;
 
     const relation = model.model.relations.find((r) => r.name === relationName);
-    if (!relation) {
-      throw new Error(
-        `Relation '${relationName}' not found on model '${model.name}'`,
+
+    if (relation) {
+      const keys = Object.fromEntries(
+        relation.references.map((ref) => [
+          appBuilder.nameFromId(ref.localRef),
+          appBuilder.nameFromId(ref.foreignRef),
+        ]),
       );
+      if (Object.entries(keys).some(([local, target]) => !local || !target)) {
+        throw new Error(
+          `Could not resolve FK field for relation '${relationName}' on model '${model.name}'`,
+        );
+      }
+
+      const foreignModel = ModelUtils.byIdOrThrow(
+        appBuilder.projectDefinition,
+        relation.modelRef,
+      );
+
+      resolvedVia.set(relationName, {
+        cardinality: 'one',
+        targetPolicyVar: `${lowercaseFirstChar(foreignModel.name)}Policy`,
+        keys,
+        relationName,
+      });
+      trackForeignModel(foreignModel.name);
+      continue;
     }
 
-    const keys = Object.fromEntries(
-      relation.references.map((ref) => [
-        appBuilder.nameFromId(ref.localRef),
-        appBuilder.nameFromId(ref.foreignRef),
-      ]),
+    // Reverse (has-many) relation: another model's FK points here. No local FK
+    // to map, so the relation name alone identifies the link.
+    const reverseHolder = appBuilder.projectDefinition.models.find(
+      (otherModel) =>
+        otherModel.model.relations.some(
+          (r) =>
+            r.modelRef === model.id && r.foreignRelationName === relationName,
+        ),
     );
-    if (Object.entries(keys).some(([local, target]) => !local || !target)) {
+    if (!reverseHolder) {
       throw new Error(
-        `Could not resolve FK field for relation '${relationName}' on model '${model.name}'`,
+        `Relation '${relationName}' not found on model '${model.name}' or as a reverse relation`,
       );
     }
-
-    const foreignModel = ModelUtils.byIdOrThrow(
-      appBuilder.projectDefinition,
-      relation.modelRef,
-    );
 
     resolvedVia.set(relationName, {
-      targetPolicyVar: `${lowercaseFirstChar(foreignModel.name)}Policy`,
-      keys,
+      cardinality: 'many',
+      targetPolicyVar: `${lowercaseFirstChar(reverseHolder.name)}Policy`,
       relationName,
     });
-
-    if (!foreignModelNames.includes(foreignModel.name)) {
-      foreignModelNames.push(foreignModel.name);
-    }
+    trackForeignModel(reverseHolder.name);
   }
 
   return { resolvedVia, foreignModelNames };
@@ -258,7 +290,7 @@ export function buildPoliciesForFeature(
         allNestedRefs.length > 0
           ? resolveViaLinks(appBuilder, model, allNestedRefs)
           : {
-              resolvedVia: new Map<string, ResolvedViaLink>(),
+              resolvedVia: new Map<string, ResolvedDelegationLink>(),
               foreignModelNames: [] as string[],
             };
 

--- a/packages/project-builder-server/src/compiler/backend/policy-lowering.ts
+++ b/packages/project-builder-server/src/compiler/backend/policy-lowering.ts
@@ -10,8 +10,9 @@
  * - `fieldComparison ===`  → `r.match({ field: value })` (scalar-equality fast path)
  * - `fieldComparison !==`  → `r.where(...)` (match is equality-only; where is the fallback)
  * - `hasRole` / `hasSomeRole` / `isAuthenticated` → `r.hasRole(...)` (global leaf)
- * - `nestedHasRole`        → `r.via(target, role, { fk, relation })`
- * - `nestedHasSomeRole`    → `r.some([ r.via(...), ... ])`
+ * - `nestedHasRole`        → `r.via(target, role, { fk, relation })` (to-one)
+ *                            or `r.viaMany(target, role, relation)` (to-many)
+ * - `nestedHasSomeRole`    → `r.some([ r.via(...)/r.viaMany(...), ... ])`
  * - `binaryLogical &&`     → `r.all([...])`
  * - `binaryLogical ||`     → `r.some([...])`
  * - `relationFilter`       → `r.where(...)` (membership stays where)
@@ -46,6 +47,8 @@ import {
  * A resolved to-one delegation link (parent policy + FK/relation), for `r.via`.
  */
 export interface ResolvedViaLink {
+  /** Delegation across a local (belongs-to) relation. */
+  cardinality: 'one';
   /** The parent policy variable name (e.g., 'todoListPolicy'). */
   targetPolicyVar: string;
   /** Local FK field → target id field (e.g. `{ todoListId: 'id' }`). */
@@ -55,12 +58,29 @@ export interface ResolvedViaLink {
 }
 
 /**
+ * A resolved to-many delegation link, for `r.viaMany`. A reverse (has-many)
+ * relation has no local FK, so the relation name alone identifies it — there is
+ * no `keys` mapping to resolve.
+ */
+export interface ResolvedViaManyLink {
+  /** Delegation across a reverse (has-many) relation. */
+  cardinality: 'many';
+  /** The target policy variable name (e.g., 'blogUserPolicy'). */
+  targetPolicyVar: string;
+  /** The reverse relation field name (e.g., 'members'). */
+  relationName: string;
+}
+
+/** A resolved delegation link of either cardinality. */
+export type ResolvedDelegationLink = ResolvedViaLink | ResolvedViaManyLink;
+
+/**
  * Context for lowering — resolved relation links for `via` delegation, and the
  * query-filter codegen context (for the `r.where` fallback paths).
  */
 export interface PolicyLoweringContext {
-  /** relation name → resolved `via` link. */
-  resolvedVia: Map<string, ResolvedViaLink>;
+  /** relation name → resolved delegation link (`via` or `viaMany`). */
+  resolvedVia: Map<string, ResolvedDelegationLink>;
   /**
    * The query-filter codegen context, used to render the `where` body for the
    * fallback kinds (`!==` comparisons, relation filters).
@@ -138,6 +158,23 @@ function renderVia(link: ResolvedViaLink, role: string): string {
 }
 
 /**
+ * Render an `r.viaMany(targetPolicyVar, 'role', 'relation')` call — existential
+ * delegation across a to-many relation ("SOME related row grants the role").
+ * No `keys`: a reverse relation has no local FK, so the relation name alone
+ * identifies the link.
+ */
+function renderViaMany(link: ResolvedViaManyLink, role: string): string {
+  return `r.viaMany(${link.targetPolicyVar}, ${quot(role)}, ${quot(link.relationName)})`;
+}
+
+/** Render a delegation of either cardinality. */
+function renderDelegation(link: ResolvedDelegationLink, role: string): string {
+  return link.cardinality === 'many'
+    ? renderViaMany(link, role)
+    : renderVia(link, role);
+}
+
+/**
  * Build the lowering visitor. Each node returns a `r.*(...)` builder-call string.
  */
 function createPolicyLoweringVisitor(
@@ -192,7 +229,7 @@ function createPolicyLoweringVisitor(
           `No resolved via link for relation '${node.relationName}'`,
         );
       }
-      return renderVia(link, node.role);
+      return renderDelegation(link, node.role);
     },
     nestedHasSomeRole(node) {
       const link = ctx.resolvedVia.get(node.relationName);
@@ -201,7 +238,7 @@ function createPolicyLoweringVisitor(
           `No resolved via link for relation '${node.relationName}'`,
         );
       }
-      const vias = node.roles.map((role) => renderVia(link, role));
+      const vias = node.roles.map((role) => renderDelegation(link, role));
       return vias.length === 1 ? vias[0] : `r.some([${vias.join(', ')}])`;
     },
     relationFilter(node) {

--- a/packages/project-builder-server/src/compiler/backend/policy-lowering.unit.test.ts
+++ b/packages/project-builder-server/src/compiler/backend/policy-lowering.unit.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 
 import type {
   PolicyLoweringContext,
+  ResolvedDelegationLink,
   ResolvedViaLink,
+  ResolvedViaManyLink,
 } from './policy-lowering.js';
 
 import { lowerExpressionToRoleTree } from './policy-lowering.js';
@@ -12,19 +14,29 @@ import { lowerExpressionToRoleTree } from './policy-lowering.js';
 // that's the normal case (`BlogPost.blogId` references `Blog.id`) and the one
 // a naive "assume local name === target name" implementation gets wrong.
 const VIA_BLOG: ResolvedViaLink = {
+  cardinality: 'one',
   targetPolicyVar: 'blogPolicy',
   keys: { blogId: 'id' },
   relationName: 'blog',
 };
 
 const VIA_BLOG_USER: ResolvedViaLink = {
+  cardinality: 'one',
   targetPolicyVar: 'blogUserPolicy',
   keys: { blogId: 'blogId', userId: 'userId' },
   relationName: 'blogUser',
 };
 
+// Reverse (has-many) link: Blog.members → BlogUser. No `keys` — a reverse
+// relation has no local FK, so the relation name alone identifies it.
+const VIA_MANY_MEMBERS: ResolvedViaManyLink = {
+  cardinality: 'many',
+  targetPolicyVar: 'blogUserPolicy',
+  relationName: 'members',
+};
+
 function ctxWith(
-  via: Record<string, ResolvedViaLink> = {},
+  via: Record<string, ResolvedDelegationLink> = {},
 ): PolicyLoweringContext {
   return { resolvedVia: new Map(Object.entries(via)) };
 }
@@ -125,6 +137,41 @@ describe('lowerExpressionToRoleTree', () => {
         ),
       ).toBe(
         "r.via(blogUserPolicy, 'owner', { relation: 'blogUser', keys: { 'blogId': 'blogId', 'userId': 'userId' } })",
+      );
+    });
+  });
+
+  describe('r.viaMany — to-many (reverse relation) delegation', () => {
+    it('nestedHasRole on a reverse relation → r.viaMany (relation name only, no keys)', () => {
+      expect(
+        lower(
+          "hasRole(model.members, 'owner')",
+          ctxWith({ members: VIA_MANY_MEMBERS }),
+        ),
+      ).toBe("r.viaMany(blogUserPolicy, 'owner', 'members')");
+    });
+
+    it('nestedHasSomeRole on a reverse relation → r.some of viaMany', () => {
+      expect(
+        lower(
+          "hasSomeRole(model.members, ['owner', 'editor'])",
+          ctxWith({ members: VIA_MANY_MEMBERS }),
+        ),
+      ).toBe(
+        "r.some([r.viaMany(blogUserPolicy, 'owner', 'members'), r.viaMany(blogUserPolicy, 'editor', 'members')])",
+      );
+    });
+
+    it('mixed cardinalities in one expression each render their own form', () => {
+      // The same expression can delegate to-one and to-many; cardinality is
+      // per-link, resolved from the schema, not per-expression.
+      expect(
+        lower(
+          "hasRole(model.blog, 'owner') || hasRole(model.members, 'owner')",
+          ctxWith({ blog: VIA_BLOG, members: VIA_MANY_MEMBERS }),
+        ),
+      ).toBe(
+        "r.some([r.via(blogPolicy, 'owner', { relation: 'blog', keys: { 'blogId': 'id' } }), r.viaMany(blogUserPolicy, 'owner', 'members')])",
       );
     });
   });

--- a/packages/project-builder-server/src/compiler/backend/query-filter-codegen.ts
+++ b/packages/project-builder-server/src/compiler/backend/query-filter-codegen.ts
@@ -89,8 +89,10 @@ export function referencesOnlyGuaranteedAuthField(
  *
  * NOTE: in the unified policy world this is only invoked on LEAF nodes the
  * lowering explicitly delegates (`!==` comparisons, relation filters). The
- * combinator/role cases (`binaryLogical`, `hasRole`, `nestedHasRole`) are kept
- * here for completeness / standalone use, but the lowering handles those itself.
+ * combinator/role cases (`binaryLogical`, `hasRole`) are kept here for
+ * completeness / standalone use, but the lowering handles those itself.
+ * `nestedHasRole`/`nestedHasSomeRole` have NO where form — they need a resolved
+ * delegation link, so they throw rather than emit an unresolvable call.
  */
 function createQueryFilterCodeVisitor(
   codeContext?: QueryFilterCodeContext,
@@ -116,17 +118,17 @@ function createQueryFilterCodeVisitor(
       return 'ctx.auth.isAuthenticated';
     },
     nestedHasRole(node) {
-      const resolved = getResolvedQueryFilter(codeContext, node.relationName);
-      return `${resolved.foreignQueryFilterVar}.buildNestedWhere(ctx, ${quot(
-        resolved.relationFieldName,
-      )}, [${quot(node.role)}])`;
+      // Delegation has no standalone where form — the policy lowering renders
+      // these directly as `r.via`/`r.viaMany`, which need the resolved link
+      // (FK keys, cardinality) this context doesn't carry.
+      throw new Error(
+        `nestedHasRole on relation '${node.relationName}' has no where form — it is lowered to r.via/r.viaMany by policy-lowering.`,
+      );
     },
     nestedHasSomeRole(node) {
-      const resolved = getResolvedQueryFilter(codeContext, node.relationName);
-      const roles = node.roles.map((r) => quot(r)).join(', ');
-      return `${resolved.foreignQueryFilterVar}.buildNestedWhere(ctx, ${quot(
-        resolved.relationFieldName,
-      )}, [${roles}])`;
+      throw new Error(
+        `nestedHasSomeRole on relation '${node.relationName}' has no where form — it is lowered to r.via/r.viaMany by policy-lowering.`,
+      );
     },
     relationFilter(node) {
       return generateRelationFilterWhereCode(node, options);
@@ -169,24 +171,6 @@ function collectLogicalOperands(
     ...collectLogicalOperands(node.left, operator),
     ...collectLogicalOperands(node.right, operator),
   ];
-}
-
-function getResolvedQueryFilter(
-  codeContext: QueryFilterCodeContext | undefined,
-  relationName: string,
-): ResolvedNestedQueryFilter {
-  if (!codeContext) {
-    throw new Error(
-      `Nested query filter references relation '${relationName}' but no code context was provided`,
-    );
-  }
-  const resolved = codeContext.resolvedFilters.get(relationName);
-  if (!resolved) {
-    throw new Error(
-      `Nested query filter references relation '${relationName}' which was not resolved`,
-    );
-  }
-  return resolved;
 }
 
 /**

--- a/packages/project-builder-web/src/routes/data/models/edit.$key/-components/authorizer/authorizer-expression-autocomplete.ts
+++ b/packages/project-builder-web/src/routes/data/models/edit.$key/-components/authorizer/authorizer-expression-autocomplete.ts
@@ -233,13 +233,6 @@ export function createAuthorizerCompletions(
     (r) => r.direction === 'foreign',
   );
 
-  const localRelationCompletions: Completion[] = localRelations.map((rel) => ({
-    label: rel.relationName,
-    type: 'property',
-    detail: `→ ${rel.foreignModelName}`,
-    info: 'Belongs-to relation (use with hasRole/hasSomeRole)',
-  }));
-
   const foreignRelationCompletions: Completion[] = foreignRelations.map(
     (rel) => ({
       label: rel.relationName,
@@ -251,11 +244,25 @@ export function createAuthorizerCompletions(
 
   // hasRole/hasSomeRole accept BOTH directions: a belongs-to relation delegates
   // to-one, a has-many relation delegates existentially ("some related row
-  // grants the role").
+  // grants the role"). Relations whose target declares no authorizer roles are
+  // omitted — every role on them would fail nested-role validation.
   const delegationRelationCompletions: Completion[] = [
-    ...localRelationCompletions,
-    ...foreignRelationCompletions,
-  ];
+    ...localRelations,
+    ...foreignRelations,
+  ]
+    .filter((rel) => rel.foreignAuthorizerRoleNames.length > 0)
+    .map((rel) => ({
+      label: rel.relationName,
+      type: 'property',
+      detail:
+        rel.direction === 'foreign'
+          ? `→ ${rel.foreignModelName}[]`
+          : `→ ${rel.foreignModelName}`,
+      info:
+        rel.direction === 'foreign'
+          ? 'Has-many relation (delegates to any related record)'
+          : 'Belongs-to relation (delegates to the related record)',
+    }));
 
   // Build role lookup maps
   const foreignRolesByRelation = new Map<string, string[]>();

--- a/packages/project-builder-web/src/routes/data/models/edit.$key/-components/authorizer/authorizer-expression-autocomplete.ts
+++ b/packages/project-builder-web/src/routes/data/models/edit.$key/-components/authorizer/authorizer-expression-autocomplete.ts
@@ -237,17 +237,25 @@ export function createAuthorizerCompletions(
     label: rel.relationName,
     type: 'property',
     detail: `→ ${rel.foreignModelName}`,
-    info: 'Relation (use with hasRole/hasSomeRole)',
+    info: 'Belongs-to relation (use with hasRole/hasSomeRole)',
   }));
 
   const foreignRelationCompletions: Completion[] = foreignRelations.map(
     (rel) => ({
       label: rel.relationName,
       type: 'property',
-      detail: `→ ${rel.foreignModelName}`,
-      info: 'Relation (use with exists/all)',
+      detail: `→ ${rel.foreignModelName}[]`,
+      info: 'Has-many relation (use with hasRole/hasSomeRole, exists/all)',
     }),
   );
+
+  // hasRole/hasSomeRole accept BOTH directions: a belongs-to relation delegates
+  // to-one, a has-many relation delegates existentially ("some related row
+  // grants the role").
+  const delegationRelationCompletions: Completion[] = [
+    ...localRelationCompletions,
+    ...foreignRelationCompletions,
+  ];
 
   // Build role lookup maps
   const foreignRolesByRelation = new Map<string, string[]>();
@@ -385,15 +393,22 @@ export function createAuthorizerCompletions(
     { label: 'false', type: 'keyword' },
   ];
 
-  // Add per-relation snippets (local → hasRole/hasSomeRole, foreign → exists/all)
-  for (const rel of localRelations) {
+  // Add per-relation snippets. hasRole/hasSomeRole work across BOTH directions:
+  // a belongs-to relation delegates to-one, a has-many relation delegates
+  // existentially ("some related row grants the role"). exists/all stay
+  // has-many only.
+  for (const rel of [...localRelations, ...foreignRelations]) {
     if (rel.foreignAuthorizerRoleNames.length > 0) {
+      const isToMany = rel.direction === 'foreign';
+      const subject = isToMany
+        ? `any related ${rel.foreignModelName}`
+        : `the related ${rel.foreignModelName}`;
       topLevelCompletions.push(
         snippetCompletion(`hasRole(model.${rel.relationName}, '\${role}')`, {
           label: `hasRole(model.${rel.relationName})`,
           type: 'method',
           detail: `→ ${rel.foreignModelName} authorizer`,
-          info: `Check if user has a role on the related ${rel.foreignModelName}`,
+          info: `Check if user has a role on ${subject}`,
           boost: -1,
         }),
         snippetCompletion(
@@ -402,7 +417,7 @@ export function createAuthorizerCompletions(
             label: `hasSomeRole(model.${rel.relationName})`,
             type: 'method',
             detail: `→ ${rel.foreignModelName} authorizer`,
-            info: `Check if user has any role on the related ${rel.foreignModelName}`,
+            info: `Check if user has any role on ${subject}`,
             boost: -2,
           },
         ),
@@ -499,11 +514,12 @@ export function createAuthorizerCompletions(
       case 'modelRelation': {
         const word = context.matchBefore(/model\.\w*/);
         if (!word) return null;
-        // hasRole/hasSomeRole use local (belongs-to) relations; exists/all use foreign (has-many)
+        // exists/all require a has-many relation; hasRole/hasSomeRole delegate
+        // across either direction (to-one via, or existential to-many).
         const options =
           ctxType.funcName === 'exists' || ctxType.funcName === 'all'
             ? foreignRelationCompletions
-            : localRelationCompletions;
+            : delegationRelationCompletions;
         return { from: word.from + 6, options };
       }
 

--- a/packages/project-builder-web/src/routes/data/models/edit.$key/-components/authorizer/authorizer-expression-autocomplete.unit.test.ts
+++ b/packages/project-builder-web/src/routes/data/models/edit.$key/-components/authorizer/authorizer-expression-autocomplete.unit.test.ts
@@ -1,11 +1,20 @@
+import type { ModelConfig } from '@baseplate-dev/project-builder-lib';
+
+import { CompletionContext } from '@codemirror/autocomplete';
 import { javascript } from '@codemirror/lang-javascript';
 import { ensureSyntaxTree } from '@codemirror/language';
 import { EditorState } from '@codemirror/state';
 import { describe, expect, it } from 'vitest';
 
-import type { ExpressionCompletionContext } from './authorizer-expression-autocomplete.js';
+import type {
+  ExpressionCompletionContext,
+  RelationAutocompleteInfo,
+} from './authorizer-expression-autocomplete.js';
 
-import { resolveExpressionCompletionContext } from './authorizer-expression-autocomplete.js';
+import {
+  createAuthorizerCompletions,
+  resolveExpressionCompletionContext,
+} from './authorizer-expression-autocomplete.js';
 
 /**
  * Create an EditorState with JavaScript language support and ensure the
@@ -194,5 +203,68 @@ describe('resolveExpressionCompletionContext', () => {
     it('should return none for whitespace only', () => {
       expect(resolve(' |')).toEqual({ type: 'none' });
     });
+  });
+});
+
+describe('createAuthorizerCompletions — relation suggestions', () => {
+  const RELATIONS: RelationAutocompleteInfo[] = [
+    {
+      relationName: 'blog',
+      foreignModelName: 'Blog',
+      foreignAuthorizerRoleNames: ['owner'],
+      direction: 'local',
+    },
+    // Has-many: hasRole delegates existentially across it (ENG-1211).
+    {
+      relationName: 'members',
+      foreignModelName: 'BlogUser',
+      foreignAuthorizerRoleNames: ['owner'],
+      direction: 'foreign',
+    },
+    // No authorizer roles on either side — every role would fail nested-role
+    // validation, so neither may be offered for hasRole/hasSomeRole.
+    {
+      relationName: 'publisher',
+      foreignModelName: 'User',
+      foreignAuthorizerRoleNames: [],
+      direction: 'local',
+    },
+    {
+      relationName: 'tags',
+      foreignModelName: 'Tag',
+      foreignAuthorizerRoleNames: [],
+      direction: 'foreign',
+    },
+  ];
+
+  const modelConfig = {
+    model: { fields: [{ name: 'id', type: 'uuid' }] },
+  } as unknown as ModelConfig;
+
+  /** Labels offered at the `model.` position inside `funcName(...)`. */
+  function relationLabelsFor(funcName: string): string[] {
+    const complete = createAuthorizerCompletions(modelConfig, [], RELATIONS);
+    const code = `${funcName}(model.`;
+    const context = new CompletionContext(createState(code), code.length, true);
+    const result = complete(context);
+    return (result?.options ?? []).map((o) => o.label);
+  }
+
+  it('hasRole offers BOTH belongs-to and has-many relations', () => {
+    const labels = relationLabelsFor('hasRole');
+    expect(labels).toContain('blog');
+    expect(labels).toContain('members');
+  });
+
+  it('hasRole omits relations whose target declares no authorizer roles', () => {
+    const labels = relationLabelsFor('hasRole');
+    expect(labels).not.toContain('publisher');
+    expect(labels).not.toContain('tags');
+  });
+
+  it('exists offers has-many relations only', () => {
+    const labels = relationLabelsFor('exists');
+    expect(labels).toContain('members');
+    expect(labels).not.toContain('blog');
   });
 });

--- a/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/dev-agents-config.generator.ts
+++ b/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/dev-agents-config.generator.ts
@@ -129,6 +129,9 @@ export const devAgentsConfigGenerator = createGenerator({
               }),
             );
 
+            // Always generate .agents/authorization.md
+            await builder.apply(renderers.authorizationMd.render({}));
+
             // Conditionally generate Claude-specific files
             if (descriptor.enabledAgents.includes('claude-code')) {
               await builder.apply(renderers.claudeMd.render({}));

--- a/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/extractor.json
+++ b/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/extractor.json
@@ -7,11 +7,18 @@
       "pathRootRelativePath": "{package-root}/AGENTS.md",
       "sourceFile": "package/AGENTS.md",
       "variables": {
-        "TPL_PROJECT_NAME": { "description": "Name of the project" },
         "TPL_APPS_LIST": {
           "description": "Markdown list of applications with types and directories"
-        }
+        },
+        "TPL_PROJECT_NAME": { "description": "Name of the project" }
       }
+    },
+    "authorization-md": {
+      "type": "text",
+      "fileOptions": { "kind": "singleton" },
+      "pathRootRelativePath": "{package-root}/.agents/authorization.md",
+      "sourceFile": "package/agents/authorization.md",
+      "variables": {}
     },
     "baseplate-md": {
       "type": "text",

--- a/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/generated/template-paths.ts
+++ b/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/generated/template-paths.ts
@@ -3,6 +3,7 @@ import { createGeneratorTask, createProviderType } from '@baseplate-dev/sync';
 
 export interface DevAgentsCoreDevAgentsConfigPaths {
   agentsMd: string;
+  authorizationMd: string;
   baseplateMd: string;
   claudeMd: string;
 }
@@ -25,6 +26,7 @@ const devAgentsCoreDevAgentsConfigPathsTask = createGeneratorTask({
       providers: {
         devAgentsCoreDevAgentsConfigPaths: {
           agentsMd: `${packageRoot}/AGENTS.md`,
+          authorizationMd: `${packageRoot}/.agents/authorization.md`,
           baseplateMd: `${packageRoot}/.agents/baseplate.md`,
           claudeMd: `${packageRoot}/CLAUDE.md`,
         },

--- a/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/generated/template-renderers.ts
+++ b/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/generated/template-renderers.ts
@@ -18,6 +18,16 @@ export interface DevAgentsCoreDevAgentsConfigRenderers {
       >,
     ) => BuilderAction;
   };
+  authorizationMd: {
+    render: (
+      options: Omit<
+        RenderTextTemplateFileActionInput<
+          typeof DEV_AGENTS_CORE_DEV_AGENTS_CONFIG_TEMPLATES.authorizationMd
+        >,
+        'destination' | 'template'
+      >,
+    ) => BuilderAction;
+  };
   baseplateMd: {
     render: (
       options: Omit<
@@ -60,6 +70,15 @@ const devAgentsCoreDevAgentsConfigRenderersTask = createGeneratorTask({
               renderTextTemplateFileAction({
                 template: DEV_AGENTS_CORE_DEV_AGENTS_CONFIG_TEMPLATES.agentsMd,
                 destination: paths.agentsMd,
+                ...options,
+              }),
+          },
+          authorizationMd: {
+            render: (options) =>
+              renderTextTemplateFileAction({
+                template:
+                  DEV_AGENTS_CORE_DEV_AGENTS_CONFIG_TEMPLATES.authorizationMd,
+                destination: paths.authorizationMd,
                 ...options,
               }),
           },

--- a/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/generated/typed-templates.ts
+++ b/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/generated/typed-templates.ts
@@ -15,6 +15,18 @@ const agentsMd = createTextTemplateFile({
   },
 });
 
+const authorizationMd = createTextTemplateFile({
+  fileOptions: { kind: 'singleton' },
+  name: 'authorization-md',
+  source: {
+    path: path.join(
+      import.meta.dirname,
+      '../templates/package/agents/authorization.md',
+    ),
+  },
+  variables: {},
+});
+
 const baseplateMd = createTextTemplateFile({
   fileOptions: { kind: 'singleton' },
   name: 'baseplate-md',
@@ -42,6 +54,7 @@ const claudeMd = createTextTemplateFile({
 
 export const DEV_AGENTS_CORE_DEV_AGENTS_CONFIG_TEMPLATES = {
   agentsMd,
+  authorizationMd,
   baseplateMd,
   claudeMd,
 };

--- a/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/templates/package/AGENTS.md
+++ b/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/templates/package/AGENTS.md
@@ -56,3 +56,4 @@ This is a pnpm monorepo managed with Turborepo. Key directories:
 This project uses Baseplate for code generation. The project definition is stored in `baseplate/project-definition.json`.
 
 - See `.agents/baseplate.md` for how to use the Baseplate MCP server, modify data models, and manage plugins
+- See `.agents/authorization.md` for the authorization model and the expression DSL used by model roles

--- a/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/templates/package/CLAUDE.md
+++ b/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/templates/package/CLAUDE.md
@@ -6,4 +6,5 @@ See [AGENTS.md](AGENTS.md) for full project context, build commands, and convent
 
 - **Prefer Baseplate MCP tools** over editing `project-definition.json` directly — the MCP server validates changes and maintains referential integrity
 - See `.agents/baseplate.md` for MCP server usage, data model changes, and plugin management
+- See `.agents/authorization.md` for the authorization model and expression DSL
 - Generated code lives in `baseplate/generated/` directories — do not edit these files directly

--- a/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/templates/package/agents/authorization.md
+++ b/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/templates/package/agents/authorization.md
@@ -1,0 +1,74 @@
+# Authorization
+
+Authorization is declared in the project definition and compiled into a policy
+per model. Nothing is hand-written in the generated policy files.
+
+Each model has an **authorizer** with named **roles**. A role is a predicate over
+a row ("is this principal the owner of this blog?"). Actions (`read`, `create`,
+`update`, `delete`) then grant access to a set of roles:
+
+- `roles` — instance roles, evaluated per row
+- `globalRoles` — principal-level roles (e.g. `admin`, `public`), row-independent
+
+A role compiles to both a boolean check (against a loaded row) and a Prisma
+`where` filter (to fan out over a list), derived from the same declaration — so
+"can I see this one?" and "which ones can I see?" can never disagree.
+
+## Authorization Expressions
+
+Each role's `expression` is a **JS-like boolean DSL** — it looks like TypeScript
+but only the following constructs are valid.
+
+| Construct                                    | Meaning                                                     |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| `model.<field> === userId`                   | Compare a field on the row to the principal (`!==` also OK) |
+| `model.<field> === 'literal'`                | Compare a field to a string/number/boolean literal          |
+| `isAuthenticated`                            | Any signed-in principal                                     |
+| `hasRole('admin')`                           | Principal holds a global role                               |
+| `hasSomeRole(['admin', 'editor'])`           | Principal holds any of several global roles                 |
+| `hasRole(model.<relation>, 'role')`          | **Delegate** to a role on a related model                   |
+| `hasSomeRole(model.<relation>, ['a', 'b'])`  | Delegate, matching any of several roles                     |
+| `exists(model.<relation>, { field: value })` | Some related record matches the conditions                  |
+| `all(model.<relation>, { field: value })`    | Every related record matches the conditions                 |
+| `&&`, `\|\|`                                 | Combine any of the above                                    |
+
+Available context: `model.<field>` (the row), `userId` and `isAuthenticated`
+(the principal). `userId` is the only auth property.
+
+**Delegation (`hasRole` with a relation)** is the main tool for reuse — instead
+of restating a parent's rule on the child, point at it:
+
+```js
+// BlogPost.owner — delegate to the Blog's own `owner` role (belongs-to)
+hasRole(model.blog, 'owner');
+
+// Blog.member — "some related BlogUser grants `owner`" (has-many)
+hasRole(model.members, 'owner');
+```
+
+Both relation directions work. A belongs-to relation delegates to the single
+related record; a has-many relation is **existential** — at least one related
+record must grant the role. A row with no related records is never granted the
+role, even if the delegated role is otherwise unrestricted.
+
+`exists`/`all` are the direct-predicate alternative when there is no role to
+reuse — they match on _fields_ of the related records, and require a has-many
+relation:
+
+```js
+// "I'm a member of this blog", stated inline rather than delegated
+exists(model.members, { userId: userId });
+```
+
+Prefer `hasRole(model.<relation>, ...)` when the related model already defines
+the role — it stays correct when that role's definition changes.
+
+## Editing authorization
+
+Roles live under a model's `authorizer.roles`; grants live on `graphql.queries`
+(read) and `service.{create,update,delete}`. Use `stage-patch-entity` on the
+`model` entity, then `show-draft` and `commit-draft`. The expression is
+validated on save — an unknown field, relation, or role surfaces as a warning
+rather than failing silently.
+
+See [baseplate.md](baseplate.md) for the general MCP workflow.

--- a/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/templates/package/agents/baseplate.md
+++ b/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/templates/package/agents/baseplate.md
@@ -64,6 +64,15 @@ Each model has:
 
 Common field types: `string`, `int`, `float`, `boolean`, `datetime`, `json`, `enum`
 
+## Authorization
+
+Models declare authorization as named roles whose `expression` is a JS-like
+boolean DSL (`model.userId === userId`, `hasRole(model.blog, 'owner')`,
+`exists(model.members, { userId: userId })`).
+
+See [authorization.md](authorization.md) for the full grammar, delegation across
+relations, and how to edit roles and grants.
+
 ## Tips
 
 - **Prefer MCP tools over editing `project-definition.json` directly** — The MCP server validates changes and maintains referential integrity


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization expressions can now delegate role checks across one-to-many (has-many) relationships using an “any related record” model.
  * The expression editor/autocomplete now suggests the correct relationship types for role checks.
  * Added a new example authorization member role demonstrating delegated access.
* **Bug Fixes**
  * Fixed expression building and evaluation for reverse/has-many role checks to avoid failures and prevent vacuous grants when no related records exist.
* **Documentation**
  * Added/expanded authorization DSL and editing guidance in the Blog example.
  * Updated schema output to represent authorization expressions using a DSL (not raw strings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->