### PR TITLE
feat: Support orderBy arguments in relation fields

### DIFF
--- a/.changeset/bright-frogs-speak.md
+++ b/.changeset/bright-frogs-speak.md
@@ -1,0 +1,8 @@
+---
+'@baseplate-dev/fastify-generators': patch
+'@baseplate-dev/project-builder-lib': patch
+'@baseplate-dev/project-builder-server': patch
+'@baseplate-dev/project-builder-web': patch
+---
+
+GraphQL list relation fields can now opt into orderBy arguments using the related model's sortable fields, and requesting ordering on a model with no sortable fields now fails with a clear error instead of generating an invalid schema.

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/accounts/users/schema/user.object-type.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/accounts/users/schema/user.object-type.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 
 import { builder } from '@src/plugins/graphql/builder.js';
+import { applyStableOrderBy } from '@src/plugins/graphql/sort-order.js';
 
+import { todoListOrderByInputType } from '../../../todos/schema/todo-list.object-type.js';
 import { userPolicy } from '../authorizers/user.policy.js';
 
 export const userObjectType = builder.prismaObject('User', {
@@ -19,11 +21,12 @@ export const userObjectType = builder.prismaObject('User', {
       args: {
         skip: t.arg.int({ validate: z.int().min(0) }),
         take: t.arg.int({ validate: z.int().min(0) }),
+        orderBy: t.arg({ type: [todoListOrderByInputType] }),
       },
       query: (args) => ({
         skip: args.skip ?? undefined,
         take: args.take ?? undefined,
-        orderBy: { id: 'asc' },
+        orderBy: applyStableOrderBy(args.orderBy, ['id']) ?? undefined,
       }),
     }),
     userProfile: t.relation('userProfile', { nullable: true }),

--- a/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/relation-pagination.e2e.test.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/relation-pagination.e2e.test.ts
@@ -165,4 +165,41 @@ describe('User.todoLists', () => {
 
     await fastify.close();
   });
+
+  it('orders related records by the requested fields', async () => {
+    const owner = await prisma.user.create({
+      data: { name: 'Owner', email: 'owner4@example.com' },
+    });
+    await Promise.all([
+      prisma.todoList.create({
+        data: { ownerId: owner.id, position: 3, name: 'Third' },
+      }),
+      prisma.todoList.create({
+        data: { ownerId: owner.id, position: 1, name: 'First' },
+      }),
+      prisma.todoList.create({
+        data: { ownerId: owner.id, position: 2, name: 'Second' },
+      }),
+    ]);
+
+    const fastify = await buildApp(['public', 'user'], owner.id);
+
+    const result = await queryGraphql(
+      fastify,
+      `query ($id: Uuid!, $orderBy: [TodoListOrderByInput!]) {
+        user(id: $id) {
+          todoLists(orderBy: $orderBy) { position }
+        }
+      }`,
+      { id: owner.id, orderBy: [{ position: 'ASC' }] },
+    );
+
+    expect(result.errors).toBeUndefined();
+    const user = result.data?.user as { todoLists: { position: number }[] };
+    expect(user.todoLists.map((todoList) => todoList.position)).toEqual([
+      1, 2, 3,
+    ]);
+
+    await fastify.close();
+  });
 });

--- a/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/user.object-type.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/accounts/users/schema/user.object-type.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 
 import { builder } from '@src/plugins/graphql/builder.js';
+import { applyStableOrderBy } from '@src/plugins/graphql/sort-order.js';
 
+import { todoListOrderByInputType } from '../../../todos/schema/todo-list.object-type.js';
 import { userPolicy } from '../authorizers/user.policy.js';
 
 export const userObjectType = builder.prismaObject('User', {
@@ -19,11 +21,12 @@ export const userObjectType = builder.prismaObject('User', {
       args: {
         skip: t.arg.int({ validate: z.int().min(0) }),
         take: t.arg.int({ validate: z.int().min(0) }),
+        orderBy: t.arg({ type: [todoListOrderByInputType] }),
       },
       query: (args) => ({
         skip: args.skip ?? undefined,
         take: args.take ?? undefined,
-        orderBy: { id: 'asc' },
+        orderBy: applyStableOrderBy(args.orderBy, ['id']) ?? undefined,
       }),
     }),
     userProfile: t.relation('userProfile', { nullable: true }),

--- a/examples/todo-with-better-auth/baseplate/project-definition.json
+++ b/examples/todo-with-better-auth/baseplate/project-definition.json
@@ -1418,7 +1418,7 @@
           ],
           "foreignRelations": [
             { "ref": "roles" },
-            { "paginated": true, "ref": "todoLists" },
+            { "orderable": true, "paginated": true, "ref": "todoLists" },
             { "ref": "userProfile" },
             { "ref": "customer" }
           ]

--- a/packages/fastify-generators/src/generators/pothos/pothos-prisma-object/pothos-prisma-object.generator.ts
+++ b/packages/fastify-generators/src/generators/pothos/pothos-prisma-object/pothos-prisma-object.generator.ts
@@ -24,11 +24,14 @@ import {
   writePothosExposeFieldFromDtoScalarField,
 } from '#src/writers/pothos/index.js';
 
+import type { PothosTypeOutputProvider } from '../_providers/index.js';
+
 import {
   pothosFieldScope,
   pothosTypeOutputProvider,
 } from '../_providers/index.js';
 import { pothosAuthProvider } from '../pothos-auth/index.js';
+import { pothosSortOrderProvider } from '../pothos-sort-order/index.js';
 import { pothosTypesFileProvider } from '../pothos-types-file/index.js';
 import { pothosSchemaBaseTypesProvider } from '../pothos/index.js';
 
@@ -37,6 +40,7 @@ const exposedFieldSchema = z.object({
   globalRoles: z.array(z.string().min(1)).default([]),
   instanceRoles: z.array(z.string().min(1)).default([]),
   paginated: z.boolean().default(false),
+  orderByInputRef: z.string().min(1).optional(),
 });
 
 const descriptorSchema = z.object({
@@ -72,220 +76,293 @@ export const pothosPrismaObjectGenerator = createGenerator({
   generatorFileUrl: import.meta.url,
   descriptorSchema,
   scopes: [pothosFieldScope],
-  buildTasks: ({ modelName, exposedFields, order }) => ({
-    main: createGeneratorTask({
-      dependencies: {
-        prismaOutput: prismaOutputProvider,
-        pothosTypeFile: pothosTypesFileProvider,
-        pothosSchemaBaseTypes: pothosSchemaBaseTypesProvider,
-        pothosAuth: pothosAuthProvider.dependency().optional(),
-        modelPolicy: prismaModelPolicyProvider
-          .dependency()
-          .optionalReference(modelName),
-      },
-      exports: {
-        pothosPrismaObject: pothosPrismaObjectProvider.export(pothosFieldScope),
-        pothosTypeOutput: pothosTypeOutputProvider.export(
-          packageScope,
-          createPothosPrismaObjectTypeOutputName(modelName),
+  buildTasks: ({ modelName, exposedFields, order }) => {
+    const orderByInputDependencies = Object.fromEntries(
+      [
+        ...new Set(
+          exposedFields.flatMap((field) => field.orderByInputRef ?? []),
         ),
-      },
-      run({
-        prismaOutput,
-        pothosTypeFile,
-        pothosSchemaBaseTypes,
-        pothosAuth,
-        modelPolicy,
-      }) {
-        const model = prismaOutput.getPrismaModel(modelName);
+      ].map((ref) => [
+        `orderByInput_${ref}`,
+        pothosTypeOutputProvider.dependency().reference(ref),
+      ]),
+    );
 
-        const variableName = `${lowerCaseFirst(model.name)}ObjectType`;
+    return {
+      main: createGeneratorTask({
+        dependencies: {
+          prismaOutput: prismaOutputProvider,
+          pothosTypeFile: pothosTypesFileProvider,
+          pothosSchemaBaseTypes: pothosSchemaBaseTypesProvider,
+          pothosAuth: pothosAuthProvider.dependency().optional(),
+          sortOrder: pothosSortOrderProvider.dependency().optional(),
+          modelPolicy: prismaModelPolicyProvider
+            .dependency()
+            .optionalReference(modelName),
+          ...(orderByInputDependencies as Record<string, never>),
+        },
+        exports: {
+          pothosPrismaObject:
+            pothosPrismaObjectProvider.export(pothosFieldScope),
+          pothosTypeOutput: pothosTypeOutputProvider.export(
+            packageScope,
+            createPothosPrismaObjectTypeOutputName(modelName),
+          ),
+        },
+        run({
+          prismaOutput,
+          pothosTypeFile,
+          pothosSchemaBaseTypes,
+          pothosAuth,
+          modelPolicy,
+          sortOrder,
+          ...dynamicDependencies
+        }) {
+          const orderByInputDependencies = dynamicDependencies as Record<
+            string,
+            PothosTypeOutputProvider
+          >;
+          const model = prismaOutput.getPrismaModel(modelName);
 
-        const customFields = createNonOverwriteableMap<
-          Record<string, TsCodeFragment>
-        >({});
+          const variableName = `${lowerCaseFirst(model.name)}ObjectType`;
 
-        // Build lookup: fieldName → auth config
-        const fieldAuthMap = new Map(
-          exposedFields
-            .filter(
-              (f) => f.globalRoles.length > 0 || f.instanceRoles.length > 0,
-            )
-            .map((f) => [
-              f.name,
-              { globalRoles: f.globalRoles, instanceRoles: f.instanceRoles },
-            ]),
-        );
+          const customFields = createNonOverwriteableMap<
+            Record<string, TsCodeFragment>
+          >({});
 
-        // Build lookup: fieldName → paginated flag
-        const fieldPaginatedMap = new Map(
-          exposedFields
-            .filter((f) => f.paginated)
-            .map((f) => [f.name, f.paginated]),
-        );
-
-        /**
-         * Build an authorize TsCodeFragment for a field, if it has auth config.
-         */
-        function buildAuthorizeFragment(
-          fieldName: string,
-        ): TsCodeFragment | undefined {
-          const fieldAuth = fieldAuthMap.get(fieldName);
-          if (!fieldAuth || !pothosAuth) {
-            return undefined;
-          }
-
-          const instanceRoleFragments = fieldAuth.instanceRoles.map(
-            (roleName) => {
-              if (!modelPolicy) {
-                throw new Error(
-                  `Field '${fieldName}' on model '${modelName}' references instance role '${roleName}' but no policy is configured for this model.`,
-                );
-              }
-              return modelPolicy.getRoleCheckFragment(roleName);
-            },
+          // Build lookup: fieldName → auth config
+          const fieldAuthMap = new Map(
+            exposedFields
+              .filter(
+                (f) => f.globalRoles.length > 0 || f.instanceRoles.length > 0,
+              )
+              .map((f) => [
+                f.name,
+                { globalRoles: f.globalRoles, instanceRoles: f.instanceRoles },
+              ]),
           );
 
-          if (
-            fieldAuth.globalRoles.length === 0 &&
-            instanceRoleFragments.length === 0
-          ) {
-            return undefined;
-          }
+          // Build lookup: fieldName → paginated flag
+          const fieldPaginatedMap = new Map(
+            exposedFields
+              .filter((f) => f.paginated)
+              .map((f) => [f.name, f.paginated]),
+          );
 
-          return pothosAuth.formatMixedAuthorizeConfig({
-            globalRoles: fieldAuth.globalRoles,
-            instanceRoleFragments,
-          });
-        }
+          const fieldOrderByInputMap = new Map(
+            exposedFields.flatMap((field) => {
+              if (!field.orderByInputRef) {
+                return [];
+              }
+              return [
+                [
+                  field.name,
+                  orderByInputDependencies[
+                    `orderByInput_${field.orderByInputRef}`
+                  ],
+                ] as const,
+              ];
+            }),
+          );
 
-        return {
-          providers: {
-            pothosPrismaObject: {
-              addCustomField: (name, expression) => {
-                customFields.set(name, expression);
-              },
-            },
-            pothosTypeOutput: {
-              getTypeReference: () =>
-                createPothosTypeReference({
-                  name: model.name,
-                  exportName: variableName,
-                  moduleSpecifier: pothosTypeFile.getModuleSpecifier(),
-                }),
-            },
-          },
-          build: () => {
-            const outputDto = prismaToServiceOutputDto(model, (enumName) =>
-              prismaOutput.getServiceEnum(enumName),
-            );
-
-            const exposedFieldNames = exposedFields.map((f) => f.name);
-
-            const missingField = exposedFieldNames.find(
-              (exposedFieldName) =>
-                !outputDto.fields.some(
-                  (field) => field.name === exposedFieldName,
-                ),
-            );
-
-            if (missingField) {
-              throw new Error(
-                `Field ${missingField} not found in model ${model.name}`,
-              );
+          /**
+           * Build an authorize TsCodeFragment for a field, if it has auth config.
+           */
+          function buildAuthorizeFragment(
+            fieldName: string,
+          ): TsCodeFragment | undefined {
+            const fieldAuth = fieldAuthMap.get(fieldName);
+            if (!fieldAuth || !pothosAuth) {
+              return undefined;
             }
 
-            const zFragment = TsCodeUtils.importFragment('z', 'zod');
-
-            const fieldDefinitions = outputDto.fields
-              .filter((field) => exposedFieldNames.includes(field.name))
-              .map((field) => {
-                const authorize = buildAuthorizeFragment(field.name);
-                const paginated = fieldPaginatedMap.get(field.name) ?? false;
-
-                if (paginated && !field.isList) {
+            const instanceRoleFragments = fieldAuth.instanceRoles.map(
+              (roleName) => {
+                if (!modelPolicy) {
                   throw new Error(
-                    `Field '${field.name}' on model '${modelName}' is marked paginated but is not a list relation.`,
+                    `Field '${fieldName}' on model '${modelName}' references instance role '${roleName}' but no policy is configured for this model.`,
                   );
                 }
-
-                let fragment: string | TsCodeFragment;
-                if (field.type === 'scalar') {
-                  fragment = writePothosExposeFieldFromDtoScalarField(field, {
-                    schemaBuilder: pothosTypeFile.getBuilderFragment(),
-                    fieldBuilder: 't',
-                    pothosSchemaBaseTypes,
-                    typeReferences: [],
-                    authorize,
-                  });
-                } else if (authorize || field.isNullable || paginated) {
-                  // Relation with options (nullable, authorize, and/or pagination)
-                  const options: Record<string, string | TsCodeFragment> = {};
-                  if (field.isNullable) {
-                    options.nullable = 'true';
-                  }
-                  if (authorize) {
-                    options.authorize = authorize;
-                  }
-                  if (paginated) {
-                    const relatedModel = prismaOutput.getPrismaModel(
-                      field.nestedType.name,
-                    );
-                    const idFieldNames = relatedModel.idFields ?? [
-                      getModelIdFieldName(relatedModel),
-                    ];
-                    const orderByFragment = TsCodeUtils.mergeFragmentsAsObject(
-                      Object.fromEntries(
-                        idFieldNames.map((name) => [name, quot('asc')]),
-                      ),
-                    );
-
-                    options.args = tsTemplate`{
-                      skip: t.arg.int({ validate: ${zFragment}.int().min(0) }),
-                      take: t.arg.int({ validate: ${zFragment}.int().min(0) }),
-                    }`;
-                    options.query = tsTemplate`(args) => ({ skip: args.skip ?? undefined, take: args.take ?? undefined, orderBy: ${orderByFragment} })`;
-                  }
-                  fragment = tsTemplate`t.relation(${quot(field.name)}, ${TsCodeUtils.mergeFragmentsAsObject(options)})`;
-                } else {
-                  // Simple relation with no options
-                  fragment = `t.relation('${field.name}')`;
-                }
-
-                return { name: field.name, fragment };
-              });
-
-            const objectTypeBlock = TsCodeUtils.formatFragment(
-              `export const VARIABLE_NAME = BUILDER.prismaObject(MODEL_NAME, {
-              fields: (t) => (FIELDS)
-            });`,
-              {
-                VARIABLE_NAME: variableName,
-                BUILDER: pothosTypeFile.getBuilderFragment(),
-                MODEL_NAME: quot(model.name),
-                FIELDS: TsCodeUtils.mergeFragmentsAsObject(
-                  {
-                    ...Object.fromEntries(
-                      fieldDefinitions.map((fieldDefinition) => [
-                        fieldDefinition.name,
-                        fieldDefinition.fragment,
-                      ]),
-                    ),
-                    ...customFields.value(),
-                  },
-                  { disableSort: true },
-                ),
+                return modelPolicy.getRoleCheckFragment(roleName);
               },
             );
 
-            pothosTypeFile.typeDefinitions.add({
-              name: model.name,
-              fragment: objectTypeBlock,
-              order,
+            if (
+              fieldAuth.globalRoles.length === 0 &&
+              instanceRoleFragments.length === 0
+            ) {
+              return undefined;
+            }
+
+            return pothosAuth.formatMixedAuthorizeConfig({
+              globalRoles: fieldAuth.globalRoles,
+              instanceRoleFragments,
             });
-          },
-        };
-      },
-    }),
-  }),
+          }
+
+          return {
+            providers: {
+              pothosPrismaObject: {
+                addCustomField: (name, expression) => {
+                  customFields.set(name, expression);
+                },
+              },
+              pothosTypeOutput: {
+                getTypeReference: () =>
+                  createPothosTypeReference({
+                    name: model.name,
+                    exportName: variableName,
+                    moduleSpecifier: pothosTypeFile.getModuleSpecifier(),
+                  }),
+              },
+            },
+            build: () => {
+              const outputDto = prismaToServiceOutputDto(model, (enumName) =>
+                prismaOutput.getServiceEnum(enumName),
+              );
+
+              const exposedFieldNames = exposedFields.map((f) => f.name);
+
+              const missingField = exposedFieldNames.find(
+                (exposedFieldName) =>
+                  !outputDto.fields.some(
+                    (field) => field.name === exposedFieldName,
+                  ),
+              );
+
+              if (missingField) {
+                throw new Error(
+                  `Field ${missingField} not found in model ${model.name}`,
+                );
+              }
+
+              const zFragment = TsCodeUtils.importFragment('z', 'zod');
+
+              const fieldDefinitions = outputDto.fields
+                .filter((field) => exposedFieldNames.includes(field.name))
+                .map((field) => {
+                  const authorize = buildAuthorizeFragment(field.name);
+                  const paginated = fieldPaginatedMap.get(field.name) ?? false;
+                  const orderByInput = fieldOrderByInputMap.get(field.name);
+
+                  if (paginated && !field.isList) {
+                    throw new Error(
+                      `Field '${field.name}' on model '${modelName}' is marked paginated but is not a list relation.`,
+                    );
+                  }
+
+                  if (orderByInput && !field.isList) {
+                    throw new Error(
+                      `Field '${field.name}' on model '${modelName}' is marked orderable but is not a list relation.`,
+                    );
+                  }
+
+                  let fragment: string | TsCodeFragment;
+                  if (field.type === 'scalar') {
+                    fragment = writePothosExposeFieldFromDtoScalarField(field, {
+                      schemaBuilder: pothosTypeFile.getBuilderFragment(),
+                      fieldBuilder: 't',
+                      pothosSchemaBaseTypes,
+                      typeReferences: [],
+                      authorize,
+                    });
+                  } else if (
+                    authorize ||
+                    field.isNullable ||
+                    paginated ||
+                    orderByInput
+                  ) {
+                    // Relation with options (nullable, authorize, pagination, and/or ordering)
+                    const options: Record<string, string | TsCodeFragment> = {};
+                    if (field.isNullable) {
+                      options.nullable = 'true';
+                    }
+                    if (authorize) {
+                      options.authorize = authorize;
+                    }
+                    // Exposing an orderBy arg without the shared helper would
+                    // accept the argument and silently ignore it.
+                    if (orderByInput && !sortOrder) {
+                      throw new Error(
+                        `Field '${field.name}' on model '${modelName}' is marked orderable but the sort order generator is not configured.`,
+                      );
+                    }
+
+                    if (paginated || orderByInput) {
+                      const relatedModel = prismaOutput.getPrismaModel(
+                        field.nestedType.name,
+                      );
+                      const idFieldNames = relatedModel.idFields ?? [
+                        getModelIdFieldName(relatedModel),
+                      ];
+                      // Ordering falls back to the ID field(s) so paginated
+                      // results stay stable when no sort is requested.
+                      const orderByFragment =
+                        orderByInput && sortOrder
+                          ? tsTemplate`${sortOrder.getApplyStableOrderByFragment()}(args.orderBy, ${JSON.stringify(idFieldNames)}) ?? undefined`
+                          : TsCodeUtils.mergeFragmentsAsObject(
+                              Object.fromEntries(
+                                idFieldNames.map((name) => [name, quot('asc')]),
+                              ),
+                            );
+                      const orderByArg = orderByInput
+                        ? tsTemplate`orderBy: t.arg({ type: [${orderByInput.getTypeReference().fragment}] }),`
+                        : '';
+
+                      options.args = paginated
+                        ? tsTemplate`{
+                      skip: t.arg.int({ validate: ${zFragment}.int().min(0) }),
+                      take: t.arg.int({ validate: ${zFragment}.int().min(0) }),
+                      ${orderByArg}
+                    }`
+                        : tsTemplate`{
+                      ${orderByArg}
+                    }`;
+                      options.query = paginated
+                        ? tsTemplate`(args) => ({ skip: args.skip ?? undefined, take: args.take ?? undefined, orderBy: ${orderByFragment} })`
+                        : tsTemplate`(args) => ({ orderBy: ${orderByFragment} })`;
+                    }
+                    fragment = tsTemplate`t.relation(${quot(field.name)}, ${TsCodeUtils.mergeFragmentsAsObject(options)})`;
+                  } else {
+                    // Simple relation with no options
+                    fragment = `t.relation('${field.name}')`;
+                  }
+
+                  return { name: field.name, fragment };
+                });
+
+              const objectTypeBlock = TsCodeUtils.formatFragment(
+                `export const VARIABLE_NAME = BUILDER.prismaObject(MODEL_NAME, {
+              fields: (t) => (FIELDS)
+            });`,
+                {
+                  VARIABLE_NAME: variableName,
+                  BUILDER: pothosTypeFile.getBuilderFragment(),
+                  MODEL_NAME: quot(model.name),
+                  FIELDS: TsCodeUtils.mergeFragmentsAsObject(
+                    {
+                      ...Object.fromEntries(
+                        fieldDefinitions.map((fieldDefinition) => [
+                          fieldDefinition.name,
+                          fieldDefinition.fragment,
+                        ]),
+                      ),
+                      ...customFields.value(),
+                    },
+                    { disableSort: true },
+                  ),
+                },
+              );
+
+              pothosTypeFile.typeDefinitions.add({
+                name: model.name,
+                fragment: objectTypeBlock,
+                order,
+              });
+            },
+          };
+        },
+      }),
+    };
+  },
 });

--- a/packages/fastify-generators/src/generators/pothos/pothos-prisma-order-by-input/pothos-prisma-order-by-input.generator.ts
+++ b/packages/fastify-generators/src/generators/pothos/pothos-prisma-order-by-input/pothos-prisma-order-by-input.generator.ts
@@ -97,6 +97,15 @@ export const pothosPrismaOrderByInputGenerator = createGenerator({
                 field.type === 'scalar' && sortableFields.includes(field.name),
             );
 
+            if (sortableScalarFields.length === 0) {
+              throw new Error(
+                `Model ${model.name} has no sortable fields but an OrderByInput type was ` +
+                  `requested. GraphQL input types must declare at least one field. Mark a ` +
+                  `scalar field on ${model.name} as sortable, or disable ordering on the ` +
+                  `list query and any relations targeting this model.`,
+              );
+            }
+
             const nonSortableField = sortableScalarFields.find((field) =>
               NON_SORTABLE_SCALAR_TYPES.has(field.scalarType),
             );

--- a/packages/project-builder-lib/src/definition/model/model-utils.ts
+++ b/packages/project-builder-lib/src/definition/model/model-utils.ts
@@ -151,6 +151,42 @@ function isFieldSafeToFilter(
   );
 }
 
+/**
+ * Returns the IDs of models that need an `OrderByInput` GraphQL type because
+ * some *other* model exposes a list relation to them marked `orderable`.
+ *
+ * The `orderable` flag lives on the *referenced* model's foreign relation
+ * entry (e.g. `User.todoLists`), but the input type belongs to the model the
+ * relation is declared on (`TodoList`, whose `owner` relation carries the
+ * matching globally-unique `foreignId`) — that is the model whose rows are
+ * being sorted.
+ *
+ * @param projectDefinition - The project definition.
+ * @returns The set of model IDs requiring an `OrderByInput` type.
+ */
+function getModelIdsRequiringOrderByInput(
+  projectDefinition: ProjectDefinition,
+): Set<string> {
+  const orderableForeignIds = new Set(
+    projectDefinition.models
+      .filter((m) => m.graphql.objectType.enabled)
+      .flatMap((m) =>
+        m.graphql.objectType.foreignRelations
+          .filter((entry) => entry.orderable)
+          .map((entry) => entry.ref),
+      ),
+  );
+  return new Set(
+    projectDefinition.models
+      .filter((m) =>
+        m.model.relations.some((relation) =>
+          orderableForeignIds.has(relation.foreignId),
+        ),
+      )
+      .map((m) => m.id),
+  );
+}
+
 export const ModelUtils = {
   byId,
   byIdOrThrow,
@@ -158,6 +194,7 @@ export const ModelUtils = {
   byNameOrThrow,
   getScalarFieldById,
   getRelationsToModel,
+  getModelIdsRequiringOrderByInput,
   getModelsForFeature,
   getModelIdFields,
   hasService,

--- a/packages/project-builder-lib/src/definition/model/model-utils.unit.test.ts
+++ b/packages/project-builder-lib/src/definition/model/model-utils.unit.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import type { ProjectDefinition } from '#src/schema/index.js';
+
 import { ModelUtils } from './model-utils.js';
 
-const { isFieldSafeToFilter } = ModelUtils;
+const { isFieldSafeToFilter, getModelIdsRequiringOrderByInput } = ModelUtils;
 
 describe('isFieldSafeToFilter', () => {
   it('is safe when the field is unrestricted, regardless of the query', () => {
@@ -66,5 +68,72 @@ describe('isFieldSafeToFilter', () => {
         { globalRoles: ['admin'], instanceRoles: ['owner', 'editor'] },
       ),
     ).toBe(false);
+  });
+});
+
+/**
+ * Builds a two-model project mirroring the real shape: `TodoList.owner`
+ * targets `User` and carries foreignId `rel-todolists`, surfaced on `User` as
+ * the `todoLists` foreign relation. The `orderable` flag lives on `User`'s
+ * entry, but the OrderByInput type must be generated on `TodoList` — the
+ * model whose rows get sorted.
+ */
+function projectWith({
+  orderable,
+  userObjectTypeEnabled = true,
+}: {
+  orderable: boolean;
+  userObjectTypeEnabled?: boolean;
+}): ProjectDefinition {
+  return {
+    models: [
+      {
+        id: 'model-todolist',
+        model: {
+          relations: [{ foreignId: 'rel-todolists', modelRef: 'model-user' }],
+        },
+        graphql: { objectType: { enabled: true, foreignRelations: [] } },
+      },
+      {
+        id: 'model-user',
+        model: { relations: [] },
+        graphql: {
+          objectType: {
+            enabled: userObjectTypeEnabled,
+            foreignRelations: [{ ref: 'rel-todolists', orderable }],
+          },
+        },
+      },
+    ],
+  } as unknown as ProjectDefinition;
+}
+
+describe('getModelIdsRequiringOrderByInput', () => {
+  it('requires an OrderByInput on the relation target when marked orderable', () => {
+    expect(
+      getModelIdsRequiringOrderByInput(projectWith({ orderable: true })),
+    ).toEqual(new Set(['model-todolist']));
+  });
+
+  it('requires nothing when the relation is not orderable', () => {
+    expect(
+      getModelIdsRequiringOrderByInput(projectWith({ orderable: false })),
+    ).toEqual(new Set());
+  });
+
+  it('ignores orderable relations on a model whose object type is disabled', () => {
+    expect(
+      getModelIdsRequiringOrderByInput(
+        projectWith({ orderable: true, userObjectTypeEnabled: false }),
+      ),
+    ).toEqual(new Set());
+  });
+
+  it('requires nothing for a project with no models', () => {
+    expect(
+      getModelIdsRequiringOrderByInput({
+        models: [],
+      } as unknown as ProjectDefinition),
+    ).toEqual(new Set());
   });
 });

--- a/packages/project-builder-lib/src/schema/models/graphql.ts
+++ b/packages/project-builder-lib/src/schema/models/graphql.ts
@@ -119,6 +119,7 @@ export const createModelGraphqlSchema = definitionSchemaWithSlots(
                   [],
                 ),
                 paginated: ctx.withDefault(z.boolean(), false),
+                orderable: ctx.withDefault(z.boolean(), false),
               }),
             )
             .apply(withByKeyMergeRule({ getKey: (item) => item.ref }))

--- a/packages/project-builder-server/src/compiler/backend/fastify.ts
+++ b/packages/project-builder-server/src/compiler/backend/fastify.ts
@@ -19,7 +19,7 @@ import {
   readmeGenerator,
   yogaPluginGenerator,
 } from '@baseplate-dev/fastify-generators';
-import { FeatureUtils } from '@baseplate-dev/project-builder-lib';
+import { FeatureUtils, ModelUtils } from '@baseplate-dev/project-builder-lib';
 import { safeMergeAll } from '@baseplate-dev/utils';
 
 import type { BackendAppEntryBuilder } from '../app-entry-builder.js';
@@ -42,10 +42,13 @@ export function buildFastify(
       model.graphql.queries.list.enabled &&
       model.graphql.queries.list.where.enabled,
   );
+  const modelIdsRequiringOrderByInput =
+    ModelUtils.getModelIdsRequiringOrderByInput(projectDefinition);
   const hasOrderBy = projectDefinition.models.some(
     (model) =>
-      model.graphql.queries.list.enabled &&
-      model.graphql.queries.list.orderBy.enabled,
+      (model.graphql.queries.list.enabled &&
+        model.graphql.queries.list.orderBy.enabled) ||
+      modelIdsRequiringOrderByInput.has(model.id),
   );
 
   // add graphql scalars

--- a/packages/project-builder-server/src/compiler/backend/graphql.ts
+++ b/packages/project-builder-server/src/compiler/backend/graphql.ts
@@ -54,6 +54,14 @@ function buildObjectTypeFile(
 
   const filterableFieldEntries = fields.filter((entry) => entry.filterable);
   const sortableFieldEntries = fields.filter((entry) => entry.sortable);
+  const relationModels = ModelUtils.getRelationsToModel(
+    appBuilder.projectDefinition,
+    model.id,
+  );
+  const requiresOrderByInputForRelation =
+    ModelUtils.getModelIdsRequiringOrderByInput(
+      appBuilder.projectDefinition,
+    ).has(model.id);
 
   if (
     queries.list.enabled &&
@@ -89,6 +97,25 @@ function buildObjectTypeFile(
     }
   }
 
+  const getOrderByInputRefForRelation = (ref: string): string => {
+    const relationModel = relationModels.find(
+      ({ relation }) => relation.foreignId === ref,
+    );
+    if (!relationModel) {
+      throw new Error(
+        `Foreign relation '${appBuilder.nameFromId(ref)}' on model '${model.name}' is marked orderable but its target model could not be resolved.`,
+      );
+    }
+    // The OrderByInput type is emitted while building the target's own object
+    // type file, so a disabled target would leave this reference dangling.
+    if (!relationModel.model.graphql.objectType.enabled) {
+      throw new Error(
+        `Foreign relation '${appBuilder.nameFromId(ref)}' on model '${model.name}' is marked orderable but its target model '${relationModel.model.name}' does not have its GraphQL object type enabled.`,
+      );
+    }
+    return getPothosPrismaOrderByInputTypeOutputName(relationModel.model.name);
+  };
+
   const toExposedField = (entry: {
     ref: string;
     globalRoles: string[];
@@ -122,6 +149,9 @@ function buildObjectTypeFile(
           ...foreignRelations.map((entry) => ({
             ...toExposedField(entry),
             paginated: entry.paginated,
+            orderByInputRef: entry.orderable
+              ? getOrderByInputRefForRelation(entry.ref)
+              : undefined,
           })),
           ...localRelations.map(toExposedField),
         ],
@@ -138,7 +168,8 @@ function buildObjectTypeFile(
             })
           : undefined,
       orderByInput:
-        queries.list.enabled && queries.list.orderBy.enabled
+        (queries.list.enabled && queries.list.orderBy.enabled) ||
+        requiresOrderByInputForRelation
           ? pothosPrismaOrderByInputGenerator({
               modelName: model.name,
               order: 3,

--- a/packages/project-builder-web/src/routes/data/models/edit.$key/-components/graphql/graph-ql-object-type-section.tsx
+++ b/packages/project-builder-web/src/routes/data/models/edit.$key/-components/graphql/graph-ql-object-type-section.tsx
@@ -18,13 +18,12 @@ import {
   SectionListSectionDescription,
   SectionListSectionHeader,
   SectionListSectionTitle,
+  SwitchField,
   SwitchFieldController,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from '@baseplate-dev/ui-components';
 import { useController, useWatch } from 'react-hook-form';
-import { HiMiniLockClosed, HiMiniQueueList } from 'react-icons/hi2';
+import { HiMiniLockClosed } from 'react-icons/hi2';
+import { MdSettings } from 'react-icons/md';
 
 interface GraphQLObjectTypeSectionProps {
   control: Control<ModelConfigInput>;
@@ -35,6 +34,7 @@ interface FieldEntry {
   globalRoles?: string[];
   instanceRoles?: string[];
   paginated?: boolean;
+  orderable?: boolean;
 }
 
 /**
@@ -86,15 +86,16 @@ function updateEntryRoles(
 }
 
 /**
- * Toggles the paginated flag on a specific field entry.
+ * Toggles a boolean flag on a specific field entry.
  */
-function updateEntryPaginated(
+function updateEntryFlag(
   entries: FieldEntry[],
   ref: string,
-  paginated: boolean,
+  key: 'paginated' | 'orderable',
+  value: boolean,
 ): FieldEntry[] {
   return entries.map((entry) =>
-    entry.ref === ref ? { ...entry, paginated } : entry,
+    entry.ref === ref ? { ...entry, [key]: value } : entry,
   );
 }
 
@@ -136,7 +137,7 @@ interface FieldEntryRowProps extends RoleOptions {
   allItems: { id: string }[];
   disabled: boolean;
   showAuth: boolean;
-  showPagination: boolean;
+  showRelationOptions: boolean;
   onChange: (entries: FieldEntry[]) => void;
 }
 
@@ -149,7 +150,7 @@ function FieldEntryRow({
   allItems,
   disabled,
   showAuth,
-  showPagination,
+  showRelationOptions,
   roleOptions,
   instanceRoleOptions,
   onChange,
@@ -181,12 +182,19 @@ function FieldEntryRow({
             e.stopPropagation();
           }}
         >
-          {showPagination && (
-            <PaginationToggle
-              paginated={entry?.paginated ?? false}
+          {showRelationOptions && (
+            <RelationOptionsPopover
+              entry={entry ?? { ref: entryRef }}
               disabled={!isChecked}
-              onChange={(paginated) => {
-                onChange(updateEntryPaginated(entries, entryRef, paginated));
+              onPaginatedChange={(paginated) => {
+                onChange(
+                  updateEntryFlag(entries, entryRef, 'paginated', paginated),
+                );
+              }}
+              onOrderableChange={(orderable) => {
+                onChange(
+                  updateEntryFlag(entries, entryRef, 'orderable', orderable),
+                );
               }}
             />
           )}
@@ -228,7 +236,7 @@ interface FieldEntryListProps extends RoleOptions {
   entries: FieldEntry[];
   disabled: boolean;
   showAuth: boolean;
-  showPagination?: boolean;
+  showRelationOptions?: boolean;
   idPrefix: string;
   onChange: (entries: FieldEntry[]) => void;
   getId?: (item: { id: string; name: string }) => string;
@@ -241,7 +249,7 @@ function FieldEntryList({
   entries,
   disabled,
   showAuth,
-  showPagination = false,
+  showRelationOptions = false,
   idPrefix,
   roleOptions,
   instanceRoleOptions,
@@ -266,7 +274,7 @@ function FieldEntryList({
               allItems={items.map((i) => ({ id: getId(i) }))}
               disabled={disabled}
               showAuth={showAuth}
-              showPagination={showPagination}
+              showRelationOptions={showRelationOptions}
               roleOptions={roleOptions}
               instanceRoleOptions={instanceRoleOptions}
               onChange={onChange}
@@ -278,42 +286,74 @@ function FieldEntryList({
   );
 }
 
-interface PaginationToggleProps {
-  paginated: boolean;
+interface RelationOptionsPopoverProps {
+  entry: FieldEntry;
   disabled?: boolean;
-  onChange: (paginated: boolean) => void;
+  onPaginatedChange: (paginated: boolean) => void;
+  onOrderableChange: (orderable: boolean) => void;
 }
 
-function PaginationToggle({
-  paginated,
+function RelationOptionsPopover({
+  entry,
   disabled,
-  onChange,
-}: PaginationToggleProps): React.ReactElement {
+  onPaginatedChange,
+  onOrderableChange,
+}: RelationOptionsPopoverProps): React.ReactElement {
+  const paginated = entry.paginated ?? false;
+  const orderable = entry.orderable ?? false;
+  const enabledNames = [
+    paginated ? 'Pagination' : undefined,
+    orderable ? 'Ordering' : undefined,
+  ].filter((name) => name !== undefined);
+
   return (
-    <Tooltip>
-      <TooltipTrigger
+    <Popover>
+      <PopoverTrigger
+        disabled={disabled}
         render={
           <button
             type="button"
-            aria-pressed={paginated}
             disabled={disabled}
-            className="flex h-6 items-center justify-center rounded px-1.5 hover:bg-muted disabled:pointer-events-none disabled:opacity-40"
-            onClick={() => {
-              onChange(!paginated);
-            }}
+            title="Configure relation arguments"
+            className="flex h-6 cursor-pointer items-center justify-end gap-1.5 rounded px-1.5 text-xs hover:bg-muted disabled:pointer-events-none disabled:opacity-40"
           />
         }
       >
-        <HiMiniQueueList
-          className={paginated ? 'text-primary' : 'text-muted-foreground'}
+        <MdSettings
+          className={
+            enabledNames.length > 0 ? 'text-primary' : 'text-muted-foreground'
+          }
         />
-      </TooltipTrigger>
-      <TooltipContent>
-        {paginated
-          ? 'Paginated with skip/take args'
-          : 'Enable skip/take pagination args'}
-      </TooltipContent>
-    </Tooltip>
+        {enabledNames.length > 0 && (
+          <Badge
+            variant="outline"
+            className="block max-w-48 truncate text-xs font-normal"
+          >
+            {enabledNames.join(', ')}
+          </Badge>
+        )}
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 space-y-4">
+        <div className="space-y-1">
+          <p className="py-1 text-sm font-medium">Relation Arguments</p>
+          <p className="text-xs text-muted-foreground">
+            Choose which arguments this list relation accepts.
+          </p>
+        </div>
+        <SwitchField
+          label="Pagination"
+          description="Limit results with skip/take args, e.g. posts(skip: 10, take: 5)"
+          value={paginated}
+          onChange={onPaginatedChange}
+        />
+        <SwitchField
+          label="Ordering"
+          description="Sort results with an orderBy arg using the related model's sortable fields."
+          value={orderable}
+          onChange={onOrderableChange}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -534,7 +574,7 @@ export function GraphQLObjectTypeSection({
             entries={foreignRelationsValue}
             disabled={!isObjectTypeEnabled}
             showAuth={!!isObjectTypeEnabled && hasAuthOptions}
-            showPagination={!!isObjectTypeEnabled}
+            showRelationOptions={!!isObjectTypeEnabled}
             idPrefix="foreign-rel"
             roleOptions={roleOptions}
             instanceRoleOptions={instanceRoleOptions}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GraphQL list relations can now support configurable `orderBy` arguments based on sortable fields.
  - Added relation settings in the model editor to enable pagination and ordering independently.
  - Ordering uses stable defaults when no custom ordering is provided.

- **Bug Fixes**
  - Models without sortable fields now produce a clear configuration error instead of an invalid GraphQL schema.
  - Added validation for unsupported ordering configurations and unresolved relation targets.

- **Tests**
  - Added coverage for ordered relation queries and ordering configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->