### PR TITLE
fix: Loosen criteria for orphaned files to prevent race conditions

### DIFF
--- a/.changeset/soft-jars-shake.md
+++ b/.changeset/soft-jars-shake.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/plugin-storage': patch
+---
+
+Orphaned files now get a 24 hour grace period before automatic cleanup deletes them, instead of becoming eligible immediately. This removes a foot-gun where confirming an upload without attaching it to its parent entity in the same transaction could result in the file being deleted within the hour. The grace period is measured from when the file record was last updated, so confirming an upload restarts the clock.

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/storage/services/clean-unused-files.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/storage/services/clean-unused-files.ts
@@ -6,7 +6,7 @@ import { logError } from '@src/services/error-logger.js';
 import { logger } from '@src/services/logger.js';
 import { prisma } from '@src/services/prisma.js';
 
-/** How long to keep files that were uploaded but never referenced */
+/** Grace period before an unreferenced file becomes eligible for cleanup */
 const UNREFERENCED_UPLOAD_EXPIRY_TIME_MS = 1000 * 60 * 60 * 24; // 1 day
 /** Maximum number of files to delete in a single operation */
 const CLEAN_JOB_LIMIT = 100;
@@ -15,9 +15,12 @@ const CLEAN_JOB_LIMIT = 100;
  * Finds and deletes unused files from storage and the database.
  *
  * Files are considered unused if:
- * 1. They belong to a cleanup-enabled category and have no references in ANY
- *    of the known file relations (orphaned files).
- * 2. They are pending uploads older than the expiry threshold (abandoned uploads).
+ * 1. They belong to a cleanup-enabled category, have no references in ANY of
+ *    the known file relations, and are past the expiry threshold (orphaned).
+ * 2. They are pending uploads past the expiry threshold (abandoned uploads).
+ *
+ * The orphan check ages on `updatedAt`, so the grace period restarts when an
+ * upload is confirmed.
  *
  * Deletion is performed in two phases per adapter: storage objects are deleted
  * first, then DB records. If storage deletion fails, the error is logged and
@@ -54,6 +57,7 @@ export async function cleanUnusedFiles(
                     },
                   },
                   { pendingUpload: false },
+                  { updatedAt: { lt: cutoffDate } },
                   // ALL known relations must be empty
                   ...allFileRelations.map((rel) => ({
                     [rel]: { none: {} },

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/storage/types/file-category.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/storage/types/file-category.ts
@@ -66,10 +66,13 @@ export interface FileCategory<
   readonly referencedByRelations?: readonly TReferencedByRelation[];
 
   /**
-   * If true, files in this category will not be automatically cleaned up
-   * when they become orphaned. Required when `referencedByRelations` is
-   * empty or omitted. Useful for categories where files are managed
-   * manually or should persist indefinitely.
+   * If true, confirmed files in this category will not be automatically
+   * cleaned up when they become orphaned. Required when
+   * `referencedByRelations` is empty or omitted. Useful for categories where
+   * files are managed manually or should persist indefinitely.
+   *
+   * Only governs orphan cleanup — abandoned pending uploads are always
+   * reclaimed once past the expiry threshold.
    */
   readonly disableAutoCleanup?: boolean;
 }

--- a/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/storage/utils/validate-pending-upload.ts
+++ b/examples/todo-with-better-auth/apps/backend/baseplate/generated/src/modules/storage/utils/validate-pending-upload.ts
@@ -30,7 +30,8 @@ export interface ValidatedPendingUpload {
  * - File was actually uploaded to storage
  *
  * Returns a `confirmUpload` callback that should be called inside your
- * transaction after creating/updating the parent entity.
+ * transaction after creating/updating the parent entity. A confirmed file that
+ * is never attached is reclaimed by the cleanup job after the expiry threshold.
  *
  * @param options - Validation options
  * @param options.fileId - The file ID to validate

--- a/examples/todo-with-better-auth/apps/backend/src/modules/storage/services/clean-unused-files.int.test.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/storage/services/clean-unused-files.int.test.ts
@@ -78,11 +78,16 @@ function createTestContext(): ServiceContextWith<'storage'> {
 /**
  * Helper to create a file record with a specific age and upload state.
  *
+ * Orphan cleanup keys off `updatedAt`, so both timestamps are backdated.
+ * Prisma's `@updatedAt` overwrites the column on every write, so `updatedAt`
+ * is set via raw SQL after the create rather than in the create itself.
+ *
  * @param options - File creation options
  * @param options.daysOld - How many days old the file should be
  * @param options.pendingUpload - Whether the file is still pending upload
  * @param options.adapter - The storage adapter name (defaults to 'uploads')
  * @param options.category - The file category name (defaults to 'TODO_LIST_COVER_PHOTO')
+ * @param options.updatedDaysOld - Age of `updatedAt` if it should differ from `daysOld`
  * @returns The created file's ID
  */
 async function createFileWithAge({
@@ -90,12 +95,18 @@ async function createFileWithAge({
   pendingUpload,
   adapter = 'uploads',
   category = 'TODO_LIST_COVER_PHOTO',
+  updatedDaysOld,
 }: {
   daysOld: number;
   pendingUpload: boolean;
   adapter?: string;
   category?: string;
+  updatedDaysOld?: number;
 }): Promise<string> {
+  const createdAt = new Date(Date.now() - daysOld * 24 * 60 * 60 * 1000);
+  const updatedAt = new Date(
+    Date.now() - (updatedDaysOld ?? daysOld) * 24 * 60 * 60 * 1000,
+  );
   const file = await prisma.file.create({
     data: {
       filename: `test-${Date.now()}.jpg`,
@@ -106,9 +117,10 @@ async function createFileWithAge({
       adapter,
       storagePath: `/test/path-${Date.now()}.jpg`,
       pendingUpload,
-      createdAt: new Date(Date.now() - daysOld * 24 * 60 * 60 * 1000),
+      createdAt,
     },
   });
+  await prisma.$executeRaw`UPDATE "file" SET "updated_at" = ${updatedAt} WHERE "id" = ${file.id}::uuid`;
   return file.id;
 }
 
@@ -202,10 +214,10 @@ describe('cleanUnusedFiles integration tests', () => {
   });
 
   describe('confirmed files with no relations (orphaned)', () => {
-    it('should delete file after owning entity is deleted', async () => {
+    it('should delete file after owning entity is deleted and grace period passes', async () => {
       const userId = await createTestUser();
       const fileId = await createFileWithAge({
-        daysOld: 0,
+        daysOld: 2,
         pendingUpload: false,
       });
 
@@ -225,17 +237,46 @@ describe('cleanUnusedFiles integration tests', () => {
       // Delete TodoList
       await prisma.todoList.delete({ where: { id: todoList.id } });
 
-      // Now file should be deleted (orphaned)
+      // Now file should be deleted (orphaned and past the grace period)
       expect(await cleanUnusedFiles(createTestContext())).toBe(1);
       expect(await countFiles()).toBe(0);
+    });
+
+    it('should NOT delete a recently confirmed file that was never attached', async () => {
+      // Reproduces the foot-gun: confirming an upload without assigning it in
+      // the same transaction previously made the file immediately collectable.
+      await createFileWithAge({ daysOld: 0, pendingUpload: false });
+
+      expect(await cleanUnusedFiles(createTestContext())).toBe(0);
+      expect(await countFiles()).toBe(1);
+    });
+
+    it('should delete a never-attached file once it is past the grace period', async () => {
+      await createFileWithAge({ daysOld: 2, pendingUpload: false });
+
+      expect(await cleanUnusedFiles(createTestContext())).toBe(1);
+      expect(await countFiles()).toBe(0);
+    });
+
+    it('should base the grace period on updatedAt, not createdAt', async () => {
+      // An old upload confirmed just now must still get a full grace period.
+      await createFileWithAge({
+        daysOld: 30,
+        updatedDaysOld: 0,
+        pendingUpload: false,
+      });
+
+      expect(await cleanUnusedFiles(createTestContext())).toBe(0);
+      expect(await countFiles()).toBe(1);
     });
   });
 
   describe('confirmed files with active relations', () => {
     it('should NOT delete file when entity with reference exists', async () => {
       const userId = await createTestUser();
+      // Past the grace period, so the relation check is what protects the file.
       const fileId = await createFileWithAge({
-        daysOld: 0,
+        daysOld: 2,
         pendingUpload: false,
       });
 
@@ -299,8 +340,8 @@ describe('cleanUnusedFiles integration tests', () => {
           coverPhotoId: activeFileId,
         },
       });
-      // 4. Confirmed file without relation (orphaned, should be deleted)
-      await createFileWithAge({ daysOld: 0, pendingUpload: false });
+      // 4. Confirmed file without relation, past grace period (should be deleted)
+      await createFileWithAge({ daysOld: 2, pendingUpload: false });
 
       expect(await countFiles()).toBe(4);
 
@@ -311,6 +352,9 @@ describe('cleanUnusedFiles integration tests', () => {
     });
 
     it('should NOT delete orphaned files in categories with disableAutoCleanup', async () => {
+      // Include a cleanup-enabled category alongside the protected one, so the
+      // orphan branch is actually built and the per-category filter is what
+      // spares the protected file — not the "no categories to clean" shortcut.
       fileCategoriesOverride = [
         {
           name: 'NO_CLEANUP_CATEGORY',
@@ -320,20 +364,34 @@ describe('cleanUnusedFiles integration tests', () => {
           referencedByRelations: ['todoListCoverPhoto'],
           disableAutoCleanup: true,
         },
+        {
+          name: 'TODO_LIST_COVER_PHOTO',
+          adapter: 'uploads',
+          maxFileSize: 1024 * 1024,
+          allowedMimeTypes: ['image/jpeg'],
+          referencedByRelations: ['todoListCoverPhoto'],
+        },
       ];
 
-      // Create an orphaned confirmed file in the no-cleanup category
+      // Both orphaned and past the grace period; only the category differs.
       await createFileWithAge({
-        daysOld: 0,
+        daysOld: 2,
         pendingUpload: false,
         category: 'NO_CLEANUP_CATEGORY',
+      });
+      await createFileWithAge({
+        daysOld: 2,
+        pendingUpload: false,
+        category: 'TODO_LIST_COVER_PHOTO',
       });
 
       const deletedCount = await cleanUnusedFiles(createTestContext());
 
-      // File should NOT be deleted because the category has disableAutoCleanup
-      expect(deletedCount).toBe(0);
+      // Only the cleanup-enabled file is removed
+      expect(deletedCount).toBe(1);
       expect(await countFiles()).toBe(1);
+      const [remaining] = await prisma.file.findMany();
+      expect(remaining.category).toBe('NO_CLEANUP_CATEGORY');
     });
 
     it('should only delete file when ALL relations are empty (multi-relation)', async () => {
@@ -351,7 +409,7 @@ describe('cleanUnusedFiles integration tests', () => {
       ];
 
       const fileId = await createFileWithAge({
-        daysOld: 0,
+        daysOld: 2,
         pendingUpload: false,
         category: 'MULTI_RELATION',
       });

--- a/examples/todo-with-better-auth/apps/backend/src/modules/storage/services/clean-unused-files.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/storage/services/clean-unused-files.ts
@@ -6,7 +6,7 @@ import { logError } from '@src/services/error-logger.js';
 import { logger } from '@src/services/logger.js';
 import { prisma } from '@src/services/prisma.js';
 
-/** How long to keep files that were uploaded but never referenced */
+/** Grace period before an unreferenced file becomes eligible for cleanup */
 const UNREFERENCED_UPLOAD_EXPIRY_TIME_MS = 1000 * 60 * 60 * 24; // 1 day
 /** Maximum number of files to delete in a single operation */
 const CLEAN_JOB_LIMIT = 100;
@@ -15,9 +15,12 @@ const CLEAN_JOB_LIMIT = 100;
  * Finds and deletes unused files from storage and the database.
  *
  * Files are considered unused if:
- * 1. They belong to a cleanup-enabled category and have no references in ANY
- *    of the known file relations (orphaned files).
- * 2. They are pending uploads older than the expiry threshold (abandoned uploads).
+ * 1. They belong to a cleanup-enabled category, have no references in ANY of
+ *    the known file relations, and are past the expiry threshold (orphaned).
+ * 2. They are pending uploads past the expiry threshold (abandoned uploads).
+ *
+ * The orphan check ages on `updatedAt`, so the grace period restarts when an
+ * upload is confirmed.
  *
  * Deletion is performed in two phases per adapter: storage objects are deleted
  * first, then DB records. If storage deletion fails, the error is logged and
@@ -54,6 +57,7 @@ export async function cleanUnusedFiles(
                     },
                   },
                   { pendingUpload: false },
+                  { updatedAt: { lt: cutoffDate } },
                   // ALL known relations must be empty
                   ...allFileRelations.map((rel) => ({
                     [rel]: { none: {} },

--- a/examples/todo-with-better-auth/apps/backend/src/modules/storage/types/file-category.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/storage/types/file-category.ts
@@ -66,10 +66,13 @@ export interface FileCategory<
   readonly referencedByRelations?: readonly TReferencedByRelation[];
 
   /**
-   * If true, files in this category will not be automatically cleaned up
-   * when they become orphaned. Required when `referencedByRelations` is
-   * empty or omitted. Useful for categories where files are managed
-   * manually or should persist indefinitely.
+   * If true, confirmed files in this category will not be automatically
+   * cleaned up when they become orphaned. Required when
+   * `referencedByRelations` is empty or omitted. Useful for categories where
+   * files are managed manually or should persist indefinitely.
+   *
+   * Only governs orphan cleanup — abandoned pending uploads are always
+   * reclaimed once past the expiry threshold.
    */
   readonly disableAutoCleanup?: boolean;
 }

--- a/examples/todo-with-better-auth/apps/backend/src/modules/storage/utils/validate-pending-upload.ts
+++ b/examples/todo-with-better-auth/apps/backend/src/modules/storage/utils/validate-pending-upload.ts
@@ -30,7 +30,8 @@ export interface ValidatedPendingUpload {
  * - File was actually uploaded to storage
  *
  * Returns a `confirmUpload` callback that should be called inside your
- * transaction after creating/updating the parent entity.
+ * transaction after creating/updating the parent entity. A confirmed file that
+ * is never attached is reclaimed by the cleanup job after the expiry threshold.
  *
  * @param options - Validation options
  * @param options.fileId - The file ID to validate

--- a/plugins/plugin-storage/src/generators/fastify/storage-module/templates/module/services/clean-unused-files.ts
+++ b/plugins/plugin-storage/src/generators/fastify/storage-module/templates/module/services/clean-unused-files.ts
@@ -7,7 +7,7 @@ import { logger } from '%loggerServiceImports';
 import { prisma } from '%prismaImports';
 import { groupBy } from 'es-toolkit';
 
-/** How long to keep files that were uploaded but never referenced */
+/** Grace period before an unreferenced file becomes eligible for cleanup */
 const UNREFERENCED_UPLOAD_EXPIRY_TIME_MS = 1000 * 60 * 60 * 24; // 1 day
 /** Maximum number of files to delete in a single operation */
 const CLEAN_JOB_LIMIT = 100;
@@ -16,9 +16,12 @@ const CLEAN_JOB_LIMIT = 100;
  * Finds and deletes unused files from storage and the database.
  *
  * Files are considered unused if:
- * 1. They belong to a cleanup-enabled category and have no references in ANY
- *    of the known file relations (orphaned files).
- * 2. They are pending uploads older than the expiry threshold (abandoned uploads).
+ * 1. They belong to a cleanup-enabled category, have no references in ANY of
+ *    the known file relations, and are past the expiry threshold (orphaned).
+ * 2. They are pending uploads past the expiry threshold (abandoned uploads).
+ *
+ * The orphan check ages on `updatedAt`, so the grace period restarts when an
+ * upload is confirmed.
  *
  * Deletion is performed in two phases per adapter: storage objects are deleted
  * first, then DB records. If storage deletion fails, the error is logged and
@@ -55,6 +58,7 @@ export async function cleanUnusedFiles(
                     },
                   },
                   { pendingUpload: false },
+                  { updatedAt: { lt: cutoffDate } },
                   // ALL known relations must be empty
                   ...allFileRelations.map((rel) => ({
                     [rel]: { none: {} },

--- a/plugins/plugin-storage/src/generators/fastify/storage-module/templates/module/types/file-category.ts
+++ b/plugins/plugin-storage/src/generators/fastify/storage-module/templates/module/types/file-category.ts
@@ -68,10 +68,13 @@ export interface FileCategory<
   readonly referencedByRelations?: readonly TReferencedByRelation[];
 
   /**
-   * If true, files in this category will not be automatically cleaned up
-   * when they become orphaned. Required when `referencedByRelations` is
-   * empty or omitted. Useful for categories where files are managed
-   * manually or should persist indefinitely.
+   * If true, confirmed files in this category will not be automatically
+   * cleaned up when they become orphaned. Required when
+   * `referencedByRelations` is empty or omitted. Useful for categories where
+   * files are managed manually or should persist indefinitely.
+   *
+   * Only governs orphan cleanup — abandoned pending uploads are always
+   * reclaimed once past the expiry threshold.
    */
   readonly disableAutoCleanup?: boolean;
 }

--- a/plugins/plugin-storage/src/generators/fastify/storage-module/templates/module/utils/validate-pending-upload.ts
+++ b/plugins/plugin-storage/src/generators/fastify/storage-module/templates/module/utils/validate-pending-upload.ts
@@ -31,7 +31,8 @@ export interface ValidatedPendingUpload {
  * - File was actually uploaded to storage
  *
  * Returns a `confirmUpload` callback that should be called inside your
- * transaction after creating/updating the parent entity.
+ * transaction after creating/updating the parent entity. A confirmed file that
+ * is never attached is reclaimed by the cleanup job after the expiry threshold.
  *
  * @param options - Validation options
  * @param options.fileId - The file ID to validate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 24-hour grace period before confirmed, unattached files are automatically deleted.
  * The grace period now begins from the file’s most recent update, allowing uploads or confirmations to restart the countdown.
  * Files in categories with automatic orphan cleanup disabled are retained.
  * Abandoned pending uploads continue to be cleaned up according to the existing expiry rules.

* **Documentation**
  * Clarified file cleanup behavior and category-specific retention rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->