### PR TITLE
fix: Avoid piling up repeated jobs to ensure we have only one pending…

### DIFF
--- a/.changeset/eng-1210-pg-boss-repeatable-catch-up.md
+++ b/.changeset/eng-1210-pg-boss-repeatable-catch-up.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/plugin-queue': patch
+---
+
+Fixed repeatable pg-boss jobs (e.g. scheduled cleanup jobs) being able to pile up and run back-to-back after a worker process was offline for a while, by giving repeatable-job queues pg-boss's exclusive policy so at most one pending instance can exist at a time.

--- a/examples/blog-with-auth/apps/backend/baseplate/generated/src/services/pg-boss.service.ts
+++ b/examples/blog-with-auth/apps/backend/baseplate/generated/src/services/pg-boss.service.ts
@@ -255,10 +255,16 @@ export function createQueueRuntime(
     await boss.createQueue(name, {
       deleteAfterSeconds,
       notify: true,
-      // pg-boss only deduplicates by singletonKey when the queue uses a
-      // policy that enforces it; the default `standard` policy ignores
-      // singletonKey entirely. The policy is fixed at creation time.
-      ...(binding.options?.deduplication && { policy: 'exclusive' }),
+      // pg-boss only enforces at-most-one-pending-job when the queue uses a
+      // policy that requires it; the default `standard` policy has no such
+      // constraint. Deduplicated queues need this so singletonKey is
+      // actually enforced, and repeatable queues need it so a pile-up of
+      // dispatched instances (e.g. from worker downtime) collapses to one
+      // instead of draining back-to-back once a worker reconnects. The
+      // policy is fixed at creation time.
+      ...((binding.options?.deduplication === true || !!binding.repeatable) && {
+        policy: 'exclusive',
+      }),
     });
     // createQueue is a no-op on an existing queue, so the settings above never
     // reach one an earlier deploy created. `policy` is omitted here because

--- a/examples/blog-with-auth/apps/backend/src/services/pg-boss.service.int.test.ts
+++ b/examples/blog-with-auth/apps/backend/src/services/pg-boss.service.int.test.ts
@@ -482,6 +482,39 @@ describe('pg-boss service integration tests', () => {
     }, 10_000);
   });
 
+  describe('repeatable jobs', () => {
+    it('should not pile up multiple pending instances of a repeatable job', async () => {
+      const queueName = 'test-repeatable-exclusive-queue';
+
+      const token = defineQueue<Record<string, never>>(queueName);
+      const binding = bindQueueHandler(token, {
+        handler: async () => {
+          // Never started - this test only asserts on what was written.
+        },
+        repeatable: {
+          pattern: '*/5 * * * * *',
+        },
+      });
+
+      runtime = createQueueRuntime([binding]);
+      await runtime.startWorkers({ createContext: createTestServiceContext });
+
+      // Simulates what would happen if several cron ticks dispatched to this
+      // queue while no worker was around to drain them: without exclusive
+      // policy, every dispatch would insert its own pending job row.
+      const jobIds = await runtime.enqueueBulk(token, [
+        { data: {} },
+        { data: {} },
+        { data: {} },
+      ]);
+
+      // An exclusive-policy queue admits only one pending job at a time, so
+      // the pile-up collapses to a single row instead of draining as a
+      // backlog once a worker reconnects.
+      expect(jobIds).toHaveLength(1);
+    });
+  });
+
   describe('cleanup', () => {
     it('should clean up orphaned schedules', async () => {
       const orphanedQueue = 'orphaned-repeatable-queue';

--- a/examples/blog-with-auth/apps/backend/src/services/pg-boss.service.ts
+++ b/examples/blog-with-auth/apps/backend/src/services/pg-boss.service.ts
@@ -255,10 +255,16 @@ export function createQueueRuntime(
     await boss.createQueue(name, {
       deleteAfterSeconds,
       notify: true,
-      // pg-boss only deduplicates by singletonKey when the queue uses a
-      // policy that enforces it; the default `standard` policy ignores
-      // singletonKey entirely. The policy is fixed at creation time.
-      ...(binding.options?.deduplication && { policy: 'exclusive' }),
+      // pg-boss only enforces at-most-one-pending-job when the queue uses a
+      // policy that requires it; the default `standard` policy has no such
+      // constraint. Deduplicated queues need this so singletonKey is
+      // actually enforced, and repeatable queues need it so a pile-up of
+      // dispatched instances (e.g. from worker downtime) collapses to one
+      // instead of draining back-to-back once a worker reconnects. The
+      // policy is fixed at creation time.
+      ...((binding.options?.deduplication === true || !!binding.repeatable) && {
+        policy: 'exclusive',
+      }),
     });
     // createQueue is a no-op on an existing queue, so the settings above never
     // reach one an earlier deploy created. `policy` is omitted here because

--- a/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/templates/src/services/pg-boss.service.ts
+++ b/plugins/plugin-queue/src/pg-boss/core/generators/pg-boss/templates/src/services/pg-boss.service.ts
@@ -255,10 +255,16 @@ export function createQueueRuntime(
     await boss.createQueue(name, {
       deleteAfterSeconds,
       notify: true,
-      // pg-boss only deduplicates by singletonKey when the queue uses a
-      // policy that enforces it; the default `standard` policy ignores
-      // singletonKey entirely. The policy is fixed at creation time.
-      ...(binding.options?.deduplication && { policy: 'exclusive' }),
+      // pg-boss only enforces at-most-one-pending-job when the queue uses a
+      // policy that requires it; the default `standard` policy has no such
+      // constraint. Deduplicated queues need this so singletonKey is
+      // actually enforced, and repeatable queues need it so a pile-up of
+      // dispatched instances (e.g. from worker downtime) collapses to one
+      // instead of draining back-to-back once a worker reconnects. The
+      // policy is fixed at creation time.
+      ...((binding.options?.deduplication === true || !!binding.repeatable) && {
+        policy: 'exclusive',
+      }),
     });
     // createQueue is a no-op on an existing queue, so the settings above never
     // reach one an earlier deploy created. `policy` is omitted here because


### PR DESCRIPTION
… instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed repeatable jobs accumulating multiple pending instances.
  - Ensured only one pending repeatable job runs at a time, including scheduled cleanup jobs.
  - Prevented back-to-back execution of accumulated jobs after a worker has been offline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->