### PR TITLE
feat: bump @types/node to ^24.0.0

### DIFF
--- a/.changeset/upgrade-types-node-24.md
+++ b/.changeset/upgrade-types-node-24.md
@@ -1,0 +1,6 @@
+---
+'@baseplate-dev/fastify-generators': patch
+'@baseplate-dev/react-generators': patch
+---
+
+Generated apps now use `@types/node` 24, matching the Node 24 runtime they already declare.

--- a/tests/simple/project-definition.json
+++ b/tests/simple/project-definition.json
@@ -30,7 +30,9 @@
           "enabled": true,
           "fields": [{ "ref": "id" }, { "ref": "title" }, { "ref": "content" }]
         },
-        "queries": { "get": { "enabled": true }, "list": { "enabled": true } }
+        "orderBy": { "fields": [] },
+        "queries": { "get": { "enabled": true }, "list": { "enabled": true } },
+        "where": { "fields": [] }
       },
       "id": "model:f114nGvsZGt9",
       "model": {
@@ -86,7 +88,7 @@
       "version": "0.1.0"
     }
   ],
-  "schemaVersion": 32,
+  "schemaVersion": 34,
   "settings": {
     "general": { "name": "simple", "packageScope": "", "portOffset": 3000 },
     "infrastructure": { "redis": { "enabled": false } }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated applications to use Node.js type definitions aligned with the Node.js 24 runtime.
* **Chores**
  * Published patch updates for the Fastify and React generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->