### PR TITLE
fix: Ensure that typecheck depends on build tasks

### DIFF
--- a/.changeset/turbo-typecheck-requires-build.md
+++ b/.changeset/turbo-typecheck-requires-build.md
@@ -1,0 +1,5 @@
+---
+'@baseplate-dev/project-builder-server': patch
+---
+
+The generated turbo.json typecheck task now depends on ^build, so typechecking a package waits for its workspace dependencies to be built instead of failing on a clean checkout.

--- a/examples/blog-with-auth/baseplate/generated/turbo.json
+++ b/examples/blog-with-auth/baseplate/generated/turbo.json
@@ -28,7 +28,7 @@
       "outputs": ["src/generated/prisma/**"]
     },
     "test": { "dependsOn": ["^build", "prisma:generate", "gql:generate"] },
-    "typecheck": { "dependsOn": ["prisma:generate", "gql:generate"] },
+    "typecheck": { "dependsOn": ["^build", "prisma:generate", "gql:generate"] },
     "watch": { "cache": false, "persistent": true }
   }
 }

--- a/examples/blog-with-auth/turbo.json
+++ b/examples/blog-with-auth/turbo.json
@@ -28,7 +28,7 @@
       "outputs": ["src/generated/prisma/**"]
     },
     "test": { "dependsOn": ["^build", "prisma:generate", "gql:generate"] },
-    "typecheck": { "dependsOn": ["prisma:generate", "gql:generate"] },
+    "typecheck": { "dependsOn": ["^build", "prisma:generate", "gql:generate"] },
     "watch": { "cache": false, "persistent": true }
   }
 }

--- a/examples/todo-with-better-auth/baseplate/generated/turbo.json
+++ b/examples/todo-with-better-auth/baseplate/generated/turbo.json
@@ -28,7 +28,7 @@
       "outputs": ["src/generated/prisma/**"]
     },
     "test": { "dependsOn": ["^build", "prisma:generate", "gql:generate"] },
-    "typecheck": { "dependsOn": ["prisma:generate", "gql:generate"] },
+    "typecheck": { "dependsOn": ["^build", "prisma:generate", "gql:generate"] },
     "watch": { "cache": false, "persistent": true }
   }
 }

--- a/examples/todo-with-better-auth/turbo.json
+++ b/examples/todo-with-better-auth/turbo.json
@@ -28,7 +28,7 @@
       "outputs": ["src/generated/prisma/**"]
     },
     "test": { "dependsOn": ["^build", "prisma:generate", "gql:generate"] },
-    "typecheck": { "dependsOn": ["prisma:generate", "gql:generate"] },
+    "typecheck": { "dependsOn": ["^build", "prisma:generate", "gql:generate"] },
     "watch": { "cache": false, "persistent": true }
   }
 }

--- a/packages/project-builder-server/src/compiler/root/root-package-compiler.ts
+++ b/packages/project-builder-server/src/compiler/root/root-package-compiler.ts
@@ -116,9 +116,7 @@ export class RootPackageCompiler extends PackageCompiler {
       })),
       {
         name: 'typecheck',
-        ...(prebuildTaskNames.length > 0
-          ? { dependsOn: prebuildTaskNames }
-          : {}),
+        dependsOn: ['^build', ...prebuildTaskNames],
       },
       {
         name: 'lint',

--- a/turbo.json
+++ b/turbo.json
@@ -41,6 +41,7 @@
       "outputLogs": "errors-only"
     },
     "typecheck": {
+      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$"]
     },
     "dev": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type checking by ensuring upstream build tasks complete first.
  * Applied the updated task ordering to generated projects and example applications.

* **Chores**
  * Documented the update in the upcoming patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->