### PR TITLE
feat: Support nulls in authorization expressions

### DIFF
--- a/.changeset/tall-comets-listen.md
+++ b/.changeset/tall-comets-listen.md
@@ -1,0 +1,8 @@
+---
+'@baseplate-dev/plugin-ai': patch
+'@baseplate-dev/project-builder-lib': patch
+'@baseplate-dev/project-builder-server': patch
+'@baseplate-dev/project-builder-web': patch
+---
+
+Authorization expressions can now compare an optional field against `null` (e.g. `model.engagementEffectiveAt !== null`), including as an `exists()`/`all()` condition value, so presence-gated rules no longer have to be hand-written. Comparing a required field, or a `json` field, against `null` is flagged as a warning.

--- a/examples/blog-with-auth/.agents/authorization.md
+++ b/examples/blog-with-auth/.agents/authorization.md
@@ -23,6 +23,7 @@ but only the following constructs are valid.
 | -------------------------------------------- | ----------------------------------------------------------- |
 | `model.<field> === userId`                   | Compare a field on the row to the principal (`!==` also OK) |
 | `model.<field> === 'literal'`                | Compare a field to a string/number/boolean literal          |
+| `model.<field> !== null`                     | Compare an optional field against `null` (`===` also OK)    |
 | `isAuthenticated`                            | Any signed-in principal                                     |
 | `hasRole('admin')`                           | Principal holds a global role                               |
 | `hasSomeRole(['admin', 'editor'])`           | Principal holds any of several global roles                 |

--- a/examples/blog-with-auth/baseplate/generated/.agents/authorization.md
+++ b/examples/blog-with-auth/baseplate/generated/.agents/authorization.md
@@ -23,6 +23,7 @@ but only the following constructs are valid.
 | -------------------------------------------- | ----------------------------------------------------------- |
 | `model.<field> === userId`                   | Compare a field on the row to the principal (`!==` also OK) |
 | `model.<field> === 'literal'`                | Compare a field to a string/number/boolean literal          |
+| `model.<field> !== null`                     | Compare an optional field against `null` (`===` also OK)    |
 | `isAuthenticated`                            | Any signed-in principal                                     |
 | `hasRole('admin')`                           | Principal holds a global role                               |
 | `hasSomeRole(['admin', 'editor'])`           | Principal holds any of several global roles                 |

--- a/examples/todo-with-better-auth/.agents/authorization.md
+++ b/examples/todo-with-better-auth/.agents/authorization.md
@@ -23,6 +23,7 @@ but only the following constructs are valid.
 | -------------------------------------------- | ----------------------------------------------------------- |
 | `model.<field> === userId`                   | Compare a field on the row to the principal (`!==` also OK) |
 | `model.<field> === 'literal'`                | Compare a field to a string/number/boolean literal          |
+| `model.<field> !== null`                     | Compare an optional field against `null` (`===` also OK)    |
 | `isAuthenticated`                            | Any signed-in principal                                     |
 | `hasRole('admin')`                           | Principal holds a global role                               |
 | `hasSomeRole(['admin', 'editor'])`           | Principal holds any of several global roles                 |

--- a/examples/todo-with-better-auth/baseplate/generated/.agents/authorization.md
+++ b/examples/todo-with-better-auth/baseplate/generated/.agents/authorization.md
@@ -23,6 +23,7 @@ but only the following constructs are valid.
 | -------------------------------------------- | ----------------------------------------------------------- |
 | `model.<field> === userId`                   | Compare a field on the row to the principal (`!==` also OK) |
 | `model.<field> === 'literal'`                | Compare a field to a string/number/boolean literal          |
+| `model.<field> !== null`                     | Compare an optional field against `null` (`===` also OK)    |
 | `isAuthenticated`                            | Any signed-in principal                                     |
 | `hasRole('admin')`                           | Principal holds a global role                               |
 | `hasSomeRole(['admin', 'editor'])`           | Principal holds any of several global roles                 |

--- a/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-acorn-parser.ts
+++ b/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-acorn-parser.ts
@@ -204,7 +204,7 @@ function convertBinaryExpression(node: BinaryExpression): FieldComparisonNode {
 
 /**
  * Convert an expression node to either a FieldRefNode or a LiteralValueNode.
- * Supports string, number, and boolean literals.
+ * Supports string, number, boolean, and null literals.
  */
 function convertFieldRefOrLiteral(
   node: Expression,
@@ -225,6 +225,7 @@ function convertFieldRefOrLiteral(
   if (node.type === 'Literal') {
     const { value } = node;
     if (
+      value === null ||
       typeof value === 'string' ||
       typeof value === 'number' ||
       typeof value === 'boolean'
@@ -237,7 +238,15 @@ function convertFieldRefOrLiteral(
       } satisfies LiteralValueNode;
     }
     throw new AuthorizerExpressionParseError(
-      'Unsupported literal type. Only string, number, and boolean literals are supported.',
+      'Unsupported literal type. Only string, number, boolean, and null literals are supported.',
+      node,
+    );
+  }
+  // Acorn parses `undefined` as an identifier, so it would otherwise be reported
+  // as an unknown field reference.
+  if (node.type === 'Identifier' && node.name === 'undefined') {
+    throw new AuthorizerExpressionParseError(
+      'Unsupported literal `undefined`. Use `null` instead.',
       node,
     );
   }

--- a/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-acorn-parser.unit.test.ts
+++ b/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-acorn-parser.unit.test.ts
@@ -211,10 +211,84 @@ describe('parseAuthorizerExpression', () => {
       );
     });
 
-    it('should reject null literal', () => {
-      expect(() => parseAuthorizerExpression('model.status === null')).toThrow(
+    it('should parse model.deletedAt === null', () => {
+      const result = parseAuthorizerExpression('model.deletedAt === null');
+
+      expect(result.ast).toEqual({
+        type: 'fieldComparison',
+        operator: '===',
+        left: {
+          type: 'fieldRef',
+          source: 'model',
+          field: 'deletedAt',
+          start: 0,
+          end: 15,
+        },
+        right: {
+          type: 'literalValue',
+          value: null,
+          start: 20,
+          end: 24,
+        },
+      });
+      expect(result.modelFieldRefs).toEqual(['deletedAt']);
+      expect(result.requiresModel).toBe(true);
+    });
+
+    it('should parse model.deletedAt !== null', () => {
+      const result = parseAuthorizerExpression('model.deletedAt !== null');
+
+      expect(result.ast).toEqual({
+        type: 'fieldComparison',
+        operator: '!==',
+        left: {
+          type: 'fieldRef',
+          source: 'model',
+          field: 'deletedAt',
+          start: 0,
+          end: 15,
+        },
+        right: {
+          type: 'literalValue',
+          value: null,
+          start: 20,
+          end: 24,
+        },
+      });
+    });
+
+    it('should parse null literal on left side (commutative)', () => {
+      const result = parseAuthorizerExpression('null === model.deletedAt');
+
+      expect(result.ast).toEqual({
+        type: 'fieldComparison',
+        operator: '===',
+        left: {
+          type: 'literalValue',
+          value: null,
+          start: 0,
+          end: 4,
+        },
+        right: {
+          type: 'fieldRef',
+          source: 'model',
+          field: 'deletedAt',
+          start: 9,
+          end: 24,
+        },
+      });
+    });
+
+    it('should reject comparing null to null', () => {
+      expect(() => parseAuthorizerExpression('null === null')).toThrow(
         AuthorizerExpressionParseError,
       );
+    });
+
+    it('should reject undefined, pointing at null instead', () => {
+      expect(() =>
+        parseAuthorizerExpression('model.deletedAt === undefined'),
+      ).toThrow(/Use `null` instead/);
     });
   });
 
@@ -681,6 +755,23 @@ describe('parseAuthorizerExpression', () => {
         { type: 'relationFilter' }
       >;
       expect(ast.conditions[0]?.field).toBe('isCompleted');
+    });
+
+    it('should parse exists with null literal condition', () => {
+      const result = parseAuthorizerExpression(
+        'exists(model.tasks, { deletedAt: null })',
+      );
+
+      expect(result.ast.type).toBe('relationFilter');
+      const ast = result.ast as Extract<
+        typeof result.ast,
+        { type: 'relationFilter' }
+      >;
+      expect(ast.conditions[0]?.field).toBe('deletedAt');
+      expect(ast.conditions[0]?.value).toMatchObject({
+        type: 'literalValue',
+        value: null,
+      });
     });
 
     it('should reject exists with no arguments', () => {

--- a/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-ast.ts
+++ b/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-ast.ts
@@ -28,7 +28,7 @@ export type AuthorizerExpressionNode =
 /**
  * A literal value in a comparison expression.
  *
- * Supports string, number, and boolean literal values.
+ * Supports string, number, boolean, and null literal values.
  *
  * @example
  * ```typescript
@@ -37,12 +37,15 @@ export type AuthorizerExpressionNode =
  *
  * // true in model.isPublished === true
  * { type: 'literalValue', value: true, start: 20, end: 24 }
+ *
+ * // null in model.deletedAt === null
+ * { type: 'literalValue', value: null, start: 20, end: 24 }
  * ```
  */
 export interface LiteralValueNode {
   type: 'literalValue';
   /** The literal value */
-  value: string | number | boolean;
+  value: string | number | boolean | null;
   /** Start position in the source */
   start: number;
   /** End position in the source */

--- a/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-validator.ts
+++ b/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-validator.ts
@@ -34,6 +34,8 @@ export interface RelationValidationInfo {
   foreignScalarFieldNames?: Set<string>;
   /** Field type map for the foreign model (for type-checking relation filter condition values) */
   foreignFieldTypes?: Map<string, string>;
+  /** Names of optional (nullable) fields on the foreign model (for null-literal checks) */
+  foreignNullableFieldNames?: Set<string>;
   /** Whether this is a local relation (FK on this model) or foreign/reverse (FK on the other model) */
   direction: 'local' | 'foreign';
 }
@@ -48,6 +50,8 @@ export interface ModelValidationContext {
   scalarFieldNames: Set<string>;
   /** Map of field name → field type (for literal type-checking) */
   fieldTypes: Map<string, string>;
+  /** Names of optional (nullable) fields on the model (for null-literal checks) */
+  nullableFieldNames?: Set<string>;
   /** Map of relation name → relation validation info (for nested authorizer checks) */
   relationInfo?: Map<string, RelationValidationInfo>;
 }
@@ -89,6 +93,22 @@ function getAuthRoleInfo(
       roles?.filter((role) => role.autoAssigned).map((role) => role.name),
     ),
   };
+}
+
+/**
+ * Resolve whether a field is nullable, returning `undefined` when it cannot be
+ * determined — either the model carries no nullability info, or the field does
+ * not exist (which is warned about separately).
+ */
+function resolveFieldNullability(
+  fieldName: string,
+  scalarFieldNames: Set<string> | undefined,
+  nullableFieldNames: Set<string> | undefined,
+): boolean | undefined {
+  if (!nullableFieldNames || !scalarFieldNames?.has(fieldName)) {
+    return undefined;
+  }
+  return nullableFieldNames.has(fieldName);
 }
 
 /**
@@ -160,15 +180,17 @@ export function validateAuthorizerExpression(
         fieldRef.source === 'model' &&
         literalNode !== null
       ) {
-        const fieldType = modelContext.fieldTypes.get(fieldRef.field);
-        if (fieldType) {
-          validateLiteralTypeCompatibility(
+        validateLiteralCompatibility(
+          fieldRef.field,
+          modelContext.modelName,
+          modelContext.fieldTypes.get(fieldRef.field),
+          resolveFieldNullability(
             fieldRef.field,
-            fieldType,
-            modelContext.modelName,
-            literalNode,
-          );
-        }
+            modelContext.scalarFieldNames,
+            modelContext.nullableFieldNames,
+          ),
+          literalNode,
+        );
       }
     },
     hasRole(node) {
@@ -322,31 +344,60 @@ export function validateAuthorizerExpression(
       }
 
       // Type-check literal condition values against foreign field types
-      if (
-        condition.value.type === 'literalValue' &&
-        relation.foreignFieldTypes
-      ) {
-        const foreignFieldType = relation.foreignFieldTypes.get(
+      if (condition.value.type === 'literalValue') {
+        validateLiteralCompatibility(
           condition.field,
-        );
-        if (foreignFieldType) {
-          validateLiteralTypeCompatibility(
+          relation.foreignModelName,
+          relation.foreignFieldTypes?.get(condition.field),
+          resolveFieldNullability(
             condition.field,
-            foreignFieldType,
-            relation.foreignModelName,
-            condition.value,
-          );
-        }
+            relation.foreignScalarFieldNames,
+            relation.foreignNullableFieldNames,
+          ),
+          condition.value,
+        );
       }
     }
   }
 
-  function validateLiteralTypeCompatibility(
+  /**
+   * Warn if a literal cannot match a field: an incompatible type, or `null`
+   * against a required or json field.
+   *
+   * `fieldType` and `isNullable` are `undefined` when unknown, in which case the
+   * corresponding check is skipped.
+   */
+  function validateLiteralCompatibility(
     fieldName: string,
-    fieldType: string,
     modelName: string,
+    fieldType: string | undefined,
+    isNullable: boolean | undefined,
     literalNode: LiteralValueNode,
   ): void {
+    // `null` is type-compatible with any field type, so it is checked against
+    // nullability instead. This must happen before the type switch below, which
+    // would otherwise see `typeof null === 'object'`.
+    if (literalNode.value === null) {
+      if (fieldType === 'json') {
+        // Prisma filters json nulls through `DbNull`/`JsonNull` rather than
+        // `null`, so a plain null comparison would not compile.
+        warnings.push({
+          message: `Field '${fieldName}' on model '${modelName}' is a json field, which cannot be compared to null.`,
+          start: literalNode.start,
+          end: literalNode.end,
+        });
+      } else if (isNullable === false) {
+        warnings.push({
+          message: `Field '${fieldName}' on model '${modelName}' is required and can never be null.`,
+          start: literalNode.start,
+          end: literalNode.end,
+        });
+      }
+      return;
+    }
+
+    if (!fieldType) return;
+
     const literalJsType = typeof literalNode.value;
 
     const isCompatible = (() => {
@@ -419,10 +470,10 @@ interface ExpressionContextModel {
   name: string;
   authorizer?: { roles?: readonly { name: string }[] };
   /** Top-level fields (used by raw JSON shapes) */
-  fields?: readonly { name: string; type?: string }[];
+  fields?: readonly { name: string; type?: string; isOptional?: boolean }[];
   model?: {
     /** Nested fields (used by typed ModelConfig objects) */
-    fields?: readonly { name: string; type?: string }[];
+    fields?: readonly { name: string; type?: string; isOptional?: boolean }[];
     relations?: readonly {
       name: string;
       modelRef: string;
@@ -450,7 +501,7 @@ function buildAuthorizerRoleNames(model: ExpressionContextModel): Set<string> {
  */
 function getModelFields(
   model: ExpressionContextModel,
-): readonly { name: string; type?: string }[] {
+): readonly { name: string; type?: string; isOptional?: boolean }[] {
   // Fields can be at top level (raw JSON) or nested under model (typed ModelConfig)
   return model.fields ?? model.model?.fields ?? [];
 }
@@ -458,18 +509,27 @@ function getModelFields(
 function buildFieldInfo(model: ExpressionContextModel): {
   foreignScalarFieldNames: Set<string> | undefined;
   foreignFieldTypes: Map<string, string> | undefined;
+  foreignNullableFieldNames: Set<string> | undefined;
 } {
   const fieldNames = new Set<string>();
   const fieldTypes = new Map<string, string>();
+  const nullableFieldNames = new Set<string>();
   for (const field of getModelFields(model)) {
     fieldNames.add(field.name);
     if (field.type) {
       fieldTypes.set(field.name, field.type);
     }
+    if (field.isOptional) {
+      nullableFieldNames.add(field.name);
+    }
   }
+  const hasFields = fieldNames.size > 0;
   return {
-    foreignScalarFieldNames: fieldNames.size > 0 ? fieldNames : undefined,
+    foreignScalarFieldNames: hasFields ? fieldNames : undefined,
     foreignFieldTypes: fieldTypes.size > 0 ? fieldTypes : undefined,
+    // Keyed off whether the model has fields at all: an empty set means "no
+    // nullable fields", which is different from "nullability unknown".
+    foreignNullableFieldNames: hasFields ? nullableFieldNames : undefined,
   };
 }
 
@@ -491,10 +551,14 @@ export function buildModelExpressionContext(
   // Build scalar field info for the current model
   const scalarFieldNames = new Set<string>();
   const fieldTypes = new Map<string, string>();
+  const nullableFieldNames = new Set<string>();
   for (const field of getModelFields(model)) {
     scalarFieldNames.add(field.name);
     if (field.type) {
       fieldTypes.set(field.name, field.type);
+    }
+    if (field.isOptional) {
+      nullableFieldNames.add(field.name);
     }
   }
 
@@ -555,6 +619,7 @@ export function buildModelExpressionContext(
     modelName: model.name,
     scalarFieldNames,
     fieldTypes,
+    nullableFieldNames,
     relationInfo,
   };
 }

--- a/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-validator.unit.test.ts
+++ b/packages/project-builder-lib/src/expression-parsers/authorizer/authorizer-expression-validator.unit.test.ts
@@ -43,6 +43,30 @@ function createMockPluginStore(
   ]);
 }
 
+/** Build `model.<field> <operator> null`. */
+function nullComparison(
+  field: string,
+  operator: '===' | '!==' = '!==',
+): FieldComparisonNode {
+  return {
+    type: 'fieldComparison',
+    operator,
+    left: {
+      type: 'fieldRef',
+      source: 'model',
+      field,
+      start: 0,
+      end: 6 + field.length,
+    },
+    right: {
+      type: 'literalValue',
+      value: null,
+      start: 11 + field.length,
+      end: 15 + field.length,
+    },
+  };
+}
+
 describe('validateAuthorizerExpression', () => {
   const defaultModelContext = buildModelExpressionContext(
     {
@@ -886,6 +910,177 @@ describe('validateAuthorizerExpression', () => {
       );
 
       expect(warnings).toEqual([]);
+    });
+  });
+
+  describe('null literal validation', () => {
+    const nullableModelContext = buildModelExpressionContext(
+      {
+        id: 'model-1',
+        name: 'Case',
+        fields: [
+          { name: 'id', type: 'string' },
+          { name: 'title', type: 'string' },
+          { name: 'engagementEffectiveAt', type: 'dateTime', isOptional: true },
+          { name: 'createdAt', type: 'dateTime' },
+          { name: 'metadata', type: 'json', isOptional: true },
+        ],
+      },
+      [],
+    );
+
+    it('should allow null comparison against an optional field', () => {
+      const warnings = validateAuthorizerExpression(
+        nullComparison('engagementEffectiveAt'),
+        nullableModelContext,
+        defaultPluginStore,
+        defaultDefinition,
+      );
+
+      expect(warnings).toEqual([]);
+    });
+
+    it('should allow null comparison against an optional field with ===', () => {
+      const warnings = validateAuthorizerExpression(
+        nullComparison('engagementEffectiveAt', '==='),
+        nullableModelContext,
+        defaultPluginStore,
+        defaultDefinition,
+      );
+
+      expect(warnings).toEqual([]);
+    });
+
+    it('should warn for null comparison against a required field', () => {
+      const warnings = validateAuthorizerExpression(
+        nullComparison('title'),
+        nullableModelContext,
+        defaultPluginStore,
+        defaultDefinition,
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.message).toContain("'title'");
+      expect(warnings[0]?.message).toContain("'Case'");
+      expect(warnings[0]?.message).toContain('required');
+    });
+
+    it('should warn for null comparison against a required dateTime field', () => {
+      // `dateTime` hits the type switch's permissive default, so the nullability
+      // check must not be routed through it.
+      const warnings = validateAuthorizerExpression(
+        nullComparison('createdAt'),
+        nullableModelContext,
+        defaultPluginStore,
+        defaultDefinition,
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.message).toContain("'createdAt'");
+    });
+
+    it('should warn for null comparison against an optional json field', () => {
+      // Prisma requires DbNull/JsonNull for json fields, so a plain null
+      // comparison would not compile in the generated project.
+      const warnings = validateAuthorizerExpression(
+        nullComparison('metadata'),
+        nullableModelContext,
+        defaultPluginStore,
+        defaultDefinition,
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.message).toContain("'metadata'");
+      expect(warnings[0]?.message).toContain('json');
+    });
+
+    it('should not warn when the context carries no nullability info', () => {
+      const warnings = validateAuthorizerExpression(
+        nullComparison('title'),
+        {
+          modelName: nullableModelContext.modelName,
+          scalarFieldNames: nullableModelContext.scalarFieldNames,
+          fieldTypes: nullableModelContext.fieldTypes,
+        },
+        defaultPluginStore,
+        defaultDefinition,
+      );
+
+      expect(warnings).toEqual([]);
+    });
+
+    it('should warn for null condition value against a required foreign field', () => {
+      const modelContext = buildModelExpressionContext(
+        {
+          id: 'model-1',
+          name: 'Case',
+          fields: [{ name: 'id', type: 'string' }],
+          model: { relations: [] },
+        },
+        [
+          {
+            id: 'model-2',
+            name: 'CaseVendor',
+            fields: [
+              { name: 'id', type: 'string' },
+              { name: 'caseId', type: 'string' },
+              { name: 'role', type: 'string' },
+              { name: 'removedAt', type: 'dateTime', isOptional: true },
+            ],
+            model: {
+              relations: [
+                {
+                  name: 'case',
+                  modelRef: 'model-1',
+                  foreignRelationName: 'vendors',
+                  references: [],
+                },
+              ],
+            },
+          },
+        ],
+      );
+
+      const buildAst = (field: string): RelationFilterNode => ({
+        type: 'relationFilter',
+        relationName: 'vendors',
+        relationStart: 7,
+        relationEnd: 20,
+        operator: 'some',
+        conditions: [
+          {
+            field,
+            fieldStart: 24,
+            fieldEnd: 24 + field.length,
+            value: {
+              type: 'literalValue',
+              value: null,
+              start: 26 + field.length,
+              end: 30 + field.length,
+            },
+          },
+        ],
+      });
+
+      expect(
+        validateAuthorizerExpression(
+          buildAst('removedAt'),
+          modelContext,
+          defaultPluginStore,
+          defaultDefinition,
+        ),
+      ).toEqual([]);
+
+      const warnings = validateAuthorizerExpression(
+        buildAst('role'),
+        modelContext,
+        defaultPluginStore,
+        defaultDefinition,
+      );
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.message).toContain("'role'");
+      expect(warnings[0]?.message).toContain("'CaseVendor'");
     });
   });
 

--- a/packages/project-builder-lib/src/schema/models/authorizer/authorizer.ts
+++ b/packages/project-builder-lib/src/schema/models/authorizer/authorizer.ts
@@ -40,6 +40,7 @@ export const createAuthorizerRoleSchema = definitionSchemaWithSlots(
          * - `exists()` / `all()` — quantify over a has-many relation
          *
          * @example 'model.userId === userId'
+         * @example 'model.deletedAt === null'
          * @example "hasRole('admin')"
          * @example "hasRole(model.blog, 'owner')"
          * @example 'exists(model.members, { userId: userId })'

--- a/packages/project-builder-server/src/compiler/backend/authorizer-expression-codegen-utils.ts
+++ b/packages/project-builder-server/src/compiler/backend/authorizer-expression-codegen-utils.ts
@@ -16,10 +16,10 @@ import { quot } from '@baseplate-dev/utils';
  * Serialize a literal value as a TypeScript literal string.
  *
  * - Strings are quoted with `quot()`
- * - Numbers and booleans are emitted as-is via `String()`
+ * - Numbers, booleans, and null are emitted as-is via `String()`
  */
 export function serializeLiteralValue(
-  value: string | number | boolean,
+  value: string | number | boolean | null,
 ): string {
   if (typeof value === 'string') {
     return quot(value);

--- a/packages/project-builder-server/src/compiler/backend/policy-lowering.ts
+++ b/packages/project-builder-server/src/compiler/backend/policy-lowering.ts
@@ -40,6 +40,7 @@ import {
 } from './authorizer-expression-codegen-utils.js';
 import {
   generateQueryFilterExpressionCode,
+  referencesAuthContext,
   referencesOnlyGuaranteedAuthField,
 } from './query-filter-codegen.js';
 
@@ -184,6 +185,7 @@ function createPolicyLoweringVisitor(
    * Fallback: lower any node to `r.where`/`r.userWhere` using the query-filter
    * codegen. `r.userWhere` applies when the node references `auth.userId` and
    * no other auth field — its non-null guarantee lets the null-check collapse.
+   * A node that reads nothing off the context takes no callback parameter.
    */
   const asWhere = (node: AuthorizerExpressionNode): string => {
     const useUserPrincipal = referencesOnlyGuaranteedAuthField(node);
@@ -197,9 +199,11 @@ function createPolicyLoweringVisitor(
     const wrapped = whereBody.trimStart().startsWith('{')
       ? `(${whereBody})`
       : whereBody;
-    return useUserPrincipal
-      ? `r.userWhere((session) => ${wrapped})`
-      : `r.where((ctx) => ${wrapped})`;
+    if (useUserPrincipal) {
+      return `r.userWhere((session) => ${wrapped})`;
+    }
+    const param = referencesAuthContext(node) ? '(ctx)' : '()';
+    return `r.where(${param} => ${wrapped})`;
   };
 
   return {

--- a/packages/project-builder-server/src/compiler/backend/policy-lowering.unit.test.ts
+++ b/packages/project-builder-server/src/compiler/backend/policy-lowering.unit.test.ts
@@ -1,3 +1,5 @@
+import type { FieldComparisonNode } from '@baseplate-dev/project-builder-lib';
+
 import { parseAuthorizerExpression } from '@baseplate-dev/project-builder-lib';
 import { describe, expect, it } from 'vitest';
 
@@ -88,7 +90,7 @@ describe('lowerExpressionToRoleTree', () => {
   describe('r.where — fallback for non-matchable comparisons', () => {
     it('!== falls back to r.where', () => {
       expect(lower("model.status !== 'draft'")).toBe(
-        "r.where((ctx) => ({ status: { not: 'draft' } }))",
+        "r.where(() => ({ status: { not: 'draft' } }))",
       );
     });
 
@@ -100,7 +102,35 @@ describe('lowerExpressionToRoleTree', () => {
 
     it('!== null falls back to r.where with a not-null filter', () => {
       expect(lower('model.engagementEffectiveAt !== null')).toBe(
-        'r.where((ctx) => ({ engagementEffectiveAt: { not: null } }))',
+        'r.where(() => ({ engagementEffectiveAt: { not: null } }))',
+      );
+    });
+
+    it('keeps the ctx parameter when the where body reads from it', () => {
+      // Built by hand: `userId` is the only auth field the parser accepts, and
+      // it always collapses to `r.userWhere`. Any other auth field keeps the
+      // null-guard, so the emitted body genuinely reads `ctx`.
+      const ast: FieldComparisonNode = {
+        type: 'fieldComparison',
+        operator: '!==',
+        left: {
+          type: 'fieldRef',
+          source: 'model',
+          field: 'orgId',
+          start: 0,
+          end: 11,
+        },
+        right: {
+          type: 'fieldRef',
+          source: 'auth',
+          field: 'orgId',
+          start: 16,
+          end: 21,
+        },
+      };
+
+      expect(lowerExpressionToRoleTree(ast, ctxWith())).toBe(
+        'r.where((ctx) => (ctx.auth.orgId != null ? { orgId: { not: ctx.auth.orgId } } : false))',
       );
     });
 
@@ -111,7 +141,7 @@ describe('lowerExpressionToRoleTree', () => {
           ctxWith({ members: VIA_MANY_MEMBERS }),
         ),
       ).toBe(
-        'r.all([r.where((ctx) => ({ engagementEffectiveAt: { not: null } })), ' +
+        'r.all([r.where(() => ({ engagementEffectiveAt: { not: null } })), ' +
           "r.viaMany(blogUserPolicy, 'owner', 'members')])",
       );
     });
@@ -243,7 +273,7 @@ describe('lowerExpressionToRoleTree', () => {
 
     it('exists(...) with a null condition value → r.where', () => {
       expect(lower('exists(model.members, { deletedAt: null })')).toBe(
-        'r.where((ctx) => ({ members: { some: { deletedAt: null } } }))',
+        'r.where(() => ({ members: { some: { deletedAt: null } } }))',
       );
     });
   });

--- a/packages/project-builder-server/src/compiler/backend/policy-lowering.unit.test.ts
+++ b/packages/project-builder-server/src/compiler/backend/policy-lowering.unit.test.ts
@@ -69,6 +69,12 @@ describe('lowerExpressionToRoleTree', () => {
       );
     });
 
+    it('null literal → match', () => {
+      expect(lower('model.deletedAt === null')).toBe(
+        'r.match(() => ({ deletedAt: null }))',
+      );
+    });
+
     it('model-vs-model comparison is NOT matchable → throws (never emits an out-of-scope `model` ref)', () => {
       // Both sides are model fields, so `r.match` can't bind one to a scalar.
       // It falls through to the where fallback, which rejects the comparison
@@ -89,6 +95,24 @@ describe('lowerExpressionToRoleTree', () => {
     it('!== against auth field userId falls back to r.userWhere (no null-guard)', () => {
       expect(lower('model.id !== userId')).toBe(
         'r.userWhere((session) => ({ id: { not: session.userId } }))',
+      );
+    });
+
+    it('!== null falls back to r.where with a not-null filter', () => {
+      expect(lower('model.engagementEffectiveAt !== null')).toBe(
+        'r.where((ctx) => ({ engagementEffectiveAt: { not: null } }))',
+      );
+    });
+
+    it('!== null composes with delegation across a relation', () => {
+      expect(
+        lower(
+          'model.engagementEffectiveAt !== null && hasRole(model.members, "owner")',
+          ctxWith({ members: VIA_MANY_MEMBERS }),
+        ),
+      ).toBe(
+        'r.all([r.where((ctx) => ({ engagementEffectiveAt: { not: null } })), ' +
+          "r.viaMany(blogUserPolicy, 'owner', 'members')])",
       );
     });
   });
@@ -214,6 +238,12 @@ describe('lowerExpressionToRoleTree', () => {
     it('exists(...) referencing only userId → r.userWhere (no null-guard)', () => {
       expect(lower('exists(model.members, { userId: userId })')).toBe(
         'r.userWhere((session) => ({ members: { some: { userId: session.userId } } }))',
+      );
+    });
+
+    it('exists(...) with a null condition value → r.where', () => {
+      expect(lower('exists(model.members, { deletedAt: null })')).toBe(
+        'r.where((ctx) => ({ members: { some: { deletedAt: null } } }))',
       );
     });
   });

--- a/packages/project-builder-server/src/compiler/backend/query-filter-codegen.ts
+++ b/packages/project-builder-server/src/compiler/backend/query-filter-codegen.ts
@@ -84,6 +84,30 @@ export function referencesOnlyGuaranteedAuthField(
   return authFieldRefs.length > 0 && authFieldRefs.every(isGuaranteedAuthField);
 }
 
+/** Is this operand a reference to the auth context (`ctx.auth.*` once emitted)? */
+function isAuthFieldRef(node: FieldRefNode | LiteralValueNode): boolean {
+  return node.type === 'fieldRef' && node.source === 'auth';
+}
+
+/**
+ * Does the emitted where clause read from the service context at all? `ctx` only
+ * ever appears as `ctx.auth.*`, so a node with no auth reference compiles to a
+ * closed-over constant and its callback can take no parameter.
+ */
+export function referencesAuthContext(node: AuthorizerExpressionNode): boolean {
+  return visitAuthorizerExpression<boolean>(node, {
+    fieldComparison: (n) => [n.left, n.right].some(isAuthFieldRef),
+    hasRole: () => true,
+    hasSomeRole: () => true,
+    isAuthenticated: () => true,
+    // No where form — these throw before any code is emitted.
+    nestedHasRole: () => false,
+    nestedHasSomeRole: () => false,
+    relationFilter: (n) => n.conditions.some((c) => isAuthFieldRef(c.value)),
+    binaryLogical: (n, _ctx, visit) => visit(n.left) || visit(n.right),
+  });
+}
+
 /**
  * Build a visitor that emits Prisma where-clause code from AST nodes.
  *

--- a/packages/project-builder-web/src/routes/data/models/edit.$key/-components/authorizer/authorizer-expression-autocomplete.ts
+++ b/packages/project-builder-web/src/routes/data/models/edit.$key/-components/authorizer/authorizer-expression-autocomplete.ts
@@ -311,6 +311,7 @@ export function createAuthorizerCompletions(
     },
     { label: 'true', type: 'keyword' },
     { label: 'false', type: 'keyword' },
+    { label: 'null', type: 'keyword' },
   ];
 
   const booleanValueCompletions: Completion[] = [
@@ -397,6 +398,7 @@ export function createAuthorizerCompletions(
     }),
     { label: 'true', type: 'keyword' },
     { label: 'false', type: 'keyword' },
+    { label: 'null', type: 'keyword' },
   ];
 
   // Add per-relation snippets. hasRole/hasSomeRole work across BOTH directions:

--- a/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/templates/package/agents/authorization.md
+++ b/plugins/plugin-ai/src/dev-agents/core/generators/dev-agents-config/templates/package/agents/authorization.md
@@ -23,6 +23,7 @@ but only the following constructs are valid.
 | -------------------------------------------- | ----------------------------------------------------------- |
 | `model.<field> === userId`                   | Compare a field on the row to the principal (`!==` also OK) |
 | `model.<field> === 'literal'`                | Compare a field to a string/number/boolean literal          |
+| `model.<field> !== null`                     | Compare an optional field against `null` (`===` also OK)    |
 | `isAuthenticated`                            | Any signed-in principal                                     |
 | `hasRole('admin')`                           | Principal holds a global role                               |
 | `hasSomeRole(['admin', 'editor'])`           | Principal holds any of several global roles                 |


### PR DESCRIPTION
Enhance authorization expressions to support comparisons with `null`, allowing for more flexible presence-gated rules. Additionally, streamline context handling in the code generation process.